### PR TITLE
feat(go-pkg): add go.pkg.dipak.io support with rewrites and UI

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -4,7 +4,7 @@ const ContentSecurityPolicy = `
 	style-src 'self' 'unsafe-inline';
 	child-src 'none';
 	frame-src 'none';
-	connect-src 'self' https://www.cloudflare.com https://cloudflareinsights.com https://www.google-analytics.com https://analytics.google.com https://*.doubleclick.net https://graph.dipak.io;
+	connect-src 'self' https://www.cloudflare.com https://cloudflareinsights.com https://www.google-analytics.com https://analytics.google.com https://*.doubleclick.net https://graph.dipak.io https://api.github.com;
 	img-src 'self' https://github.com https://avatars.githubusercontent.com https://www.google-analytics.com https://*.google.com https://*.google.ca data:;
 	media-src 'self';
 	font-src 'self' https://fonts.googleapis.com https://fonts.gstatic.com;
@@ -69,6 +69,28 @@ const nextConfig = {
 
   async rewrites() {
     return [
+      // go.pkg.dipak.io routes
+      {
+        source: '/',
+        has: [
+          {
+            type: 'host',
+            value: 'go.pkg.dipak.io'
+          }
+        ],
+        destination: '/go-pkg'
+      },
+      {
+        source: '/:package',
+        has: [
+          {
+            type: 'host',
+            value: 'go.pkg.dipak.io'
+          }
+        ],
+        destination: '/go-pkg/:package'
+      },
+      // dipak.bio routes
       {
         source: '/',
         has: [
@@ -79,6 +101,7 @@ const nextConfig = {
         ],
         destination: '/links'
       },
+      // Default route
       {
         source: '/',
         destination: '/home'

--- a/src/app/(go-pkg-site)/go-pkg/PackageCard.tsx
+++ b/src/app/(go-pkg-site)/go-pkg/PackageCard.tsx
@@ -1,0 +1,131 @@
+'use client';
+
+import { Badge } from '@/components/ui/badge';
+import type { Repo } from '@/lib/github';
+import Link from 'next/link';
+import { useState } from 'react';
+
+export function PackageCard({ repo }: { repo: Repo }) {
+  const [copied, setCopied] = useState(false);
+  const installCommand = `go get go.pkg.dipak.io/${repo.name}`;
+  const githubUrl = `https://github.com/dipakparmar/${repo.name}`;
+  const packageUrl = `/go-pkg/${repo.name}`;
+
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(installCommand);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <div className="group relative rounded-xl border bg-card p-5 text-card-foreground transition-all hover:border-foreground/20 hover:shadow-lg">
+      {/* Header */}
+      <div className="flex items-start justify-between gap-3">
+        <div className="space-y-1.5 flex-1">
+          <div className="flex items-center gap-2">
+            <span className="text-lg">📦</span>
+            <Link
+              href={packageUrl}
+              className="font-semibold tracking-tight hover:text-blue-500 transition-colors"
+            >
+              {repo.name}
+            </Link>
+          </div>
+          <p className="text-sm text-muted-foreground leading-relaxed">
+            {repo.description || 'No description available'}
+          </p>
+        </div>
+
+        {/* Actions */}
+        <div className="flex items-center gap-1 shrink-0">
+          {repo.stargazers_count > 0 && (
+            <Badge variant="secondary" className="text-xs mr-1">
+              ⭐ {repo.stargazers_count}
+            </Badge>
+          )}
+          <Link
+            href={packageUrl}
+            className="p-2 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+            title="View package info"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              className="h-4 w-4"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
+              />
+            </svg>
+          </Link>
+          <Link
+            href={githubUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="p-2 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+            title="View on GitHub"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              className="h-4 w-4"
+              fill="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
+            </svg>
+          </Link>
+        </div>
+      </div>
+
+      {/* Install Command */}
+      <div className="mt-4 flex items-center gap-2 rounded-md bg-zinc-900 dark:bg-zinc-950 p-3 border border-zinc-800">
+        <code className="flex-1 text-xs font-mono text-zinc-300 truncate">
+          <span className="text-zinc-500">$</span> {installCommand}
+        </code>
+        <button
+          onClick={handleCopy}
+          className="shrink-0 rounded-md p-1.5 text-zinc-400 hover:text-zinc-100 hover:bg-zinc-800 transition-colors"
+          title="Copy install command"
+          type="button"
+        >
+          {copied ? (
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              className="h-4 w-4 text-green-500"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M5 13l4 4L19 7"
+              />
+            </svg>
+          ) : (
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              className="h-4 w-4"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"
+              />
+            </svg>
+          )}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(go-pkg-site)/go-pkg/[package]/not-found.tsx
+++ b/src/app/(go-pkg-site)/go-pkg/[package]/not-found.tsx
@@ -1,0 +1,29 @@
+import Link from 'next/link';
+import { BlurFade } from '@/components/magicui/blur-fade';
+import BlurFadeText from '@/components/magicui/blur-fade-text';
+
+const BLUR_FADE_DELAY = 0.04;
+
+export default function PackageNotFound() {
+  return (
+    <main className="flex flex-col min-h-dvh items-center justify-center space-y-6">
+      <BlurFadeText
+        delay={BLUR_FADE_DELAY}
+        className="text-6xl font-bold tracking-tighter"
+        yOffset={8}
+        text="404"
+      />
+      <BlurFade delay={BLUR_FADE_DELAY * 2}>
+        <p className="text-muted-foreground">Package not found</p>
+      </BlurFade>
+      <BlurFade delay={BLUR_FADE_DELAY * 3}>
+        <Link
+          href="/go-pkg"
+          className="text-sm text-blue-500 hover:underline"
+        >
+          ← Back to all packages
+        </Link>
+      </BlurFade>
+    </main>
+  );
+}

--- a/src/app/(go-pkg-site)/go-pkg/[package]/page.tsx
+++ b/src/app/(go-pkg-site)/go-pkg/[package]/page.tsx
@@ -28,7 +28,7 @@ export default async function PackagePage({ params }: PackagePageProps) {
   const pkgName = pkgString.split('@')[0];
   const pkgVersion = pkgString.split('@')[1];
 
-  const goImportContent = buildGoImportMeta(pkgName, pkgVersion);
+  const goImportContent = buildGoImportMeta(pkgName);
   const githubUrl = getGitHubUrl(pkgName);
   const redirectUrl = pkgVersion
     ? `${githubUrl}/releases/tag/${pkgVersion}`

--- a/src/app/(go-pkg-site)/go-pkg/[package]/page.tsx
+++ b/src/app/(go-pkg-site)/go-pkg/[package]/page.tsx
@@ -1,0 +1,54 @@
+import { Metadata } from 'next';
+import Link from 'next/link';
+import { buildGoImportMeta, getGitHubUrl } from '@/lib/github';
+
+interface PackagePageProps {
+  params: Promise<{
+    package: string;
+  }>;
+}
+
+export async function generateMetadata({
+  params
+}: PackagePageProps): Promise<Metadata> {
+  const { package: pkgString } = await params;
+  const pkgName = pkgString.split('@')[0];
+
+  return {
+    title: `go.pkg.dipak.io/${pkgName}`,
+    description: `Go package: ${pkgName}`,
+    other: {
+      'go-import': buildGoImportMeta(pkgName)
+    }
+  };
+}
+
+export default async function PackagePage({ params }: PackagePageProps) {
+  const { package: pkgString } = await params;
+  const pkgName = pkgString.split('@')[0];
+  const pkgVersion = pkgString.split('@')[1];
+
+  const goImportContent = buildGoImportMeta(pkgName, pkgVersion);
+  const githubUrl = getGitHubUrl(pkgName);
+  const redirectUrl = pkgVersion
+    ? `${githubUrl}/releases/tag/${pkgVersion}`
+    : githubUrl;
+
+  return (
+    <>
+      <head>
+        <meta name="go-import" content={goImportContent} />
+        <meta httpEquiv="refresh" content={`0;URL='${redirectUrl}'`} />
+      </head>
+      <main className="flex flex-col min-h-dvh items-center justify-center space-y-4">
+        <p className="text-sm text-muted-foreground">
+          Redirecting you to the{' '}
+          <Link href={redirectUrl} className="text-blue-500 hover:underline">
+            project page
+          </Link>
+          ...
+        </p>
+      </main>
+    </>
+  );
+}

--- a/src/app/(go-pkg-site)/go-pkg/page.tsx
+++ b/src/app/(go-pkg-site)/go-pkg/page.tsx
@@ -1,0 +1,101 @@
+import { Metadata } from 'next';
+import Link from 'next/link';
+import { fetchGoPackages, Repo } from '@/lib/github';
+import { PackageCard } from './PackageCard';
+import { BlurFade } from '@/components/magicui/blur-fade';
+import BlurFadeText from '@/components/magicui/blur-fade-text';
+
+const BLUR_FADE_DELAY = 0.04;
+
+export const metadata: Metadata = {
+  title: 'Go Packages by Dipak Parmar',
+  description: 'Collection of Go packages and libraries by Dipak Parmar',
+  openGraph: {
+    title: 'Go Packages by Dipak Parmar',
+    description: 'Collection of Go packages and libraries by Dipak Parmar',
+    url: 'https://go.pkg.dipak.io',
+    siteName: 'go.pkg.dipak.io',
+    type: 'website'
+  },
+  alternates: {
+    canonical: 'https://go.pkg.dipak.io'
+  }
+};
+
+export const revalidate = 3600;
+
+export default async function GoPackagesHome() {
+  const repositories = await fetchGoPackages();
+
+  return (
+    <main className="flex flex-col min-h-dvh space-y-10">
+      <section id="hero">
+        <div className="mx-auto w-full max-w-2xl space-y-8">
+          <div className="flex-col flex flex-1 space-y-1.5">
+            <BlurFadeText
+              delay={BLUR_FADE_DELAY}
+              className="text-3xl font-bold tracking-tighter sm:text-5xl xl:text-6xl/none"
+              yOffset={8}
+              text="Go Packages 📦"
+            />
+            <BlurFadeText
+              className="max-w-150 md:text-xl"
+              delay={BLUR_FADE_DELAY * 2}
+              text="Collection of Go packages and libraries"
+            />
+          </div>
+        </div>
+      </section>
+
+      <section id="install">
+        <BlurFade delay={BLUR_FADE_DELAY * 3}>
+          <h2 className="text-xl font-bold">Installation</h2>
+        </BlurFade>
+        <BlurFade delay={BLUR_FADE_DELAY * 4}>
+          <p className="text-sm text-muted-foreground mt-2">
+            Install any package with{' '}
+            <code className="rounded-md bg-muted px-2 py-1 font-mono text-sm">
+              go get go.pkg.dipak.io/package-name
+            </code>
+          </p>
+        </BlurFade>
+      </section>
+
+      <section id="packages">
+        <BlurFade delay={BLUR_FADE_DELAY * 5}>
+          <h2 className="text-xl font-bold">Packages</h2>
+        </BlurFade>
+        <div className="mt-4 grid gap-4">
+          {repositories.map((repo: Repo, index: number) => (
+            <BlurFade key={repo.id} delay={BLUR_FADE_DELAY * 6 + index * 0.05}>
+              <PackageCard repo={repo} />
+            </BlurFade>
+          ))}
+        </div>
+
+        {repositories.length === 0 && (
+          <BlurFade delay={BLUR_FADE_DELAY * 6}>
+            <p className="mt-4 text-sm text-muted-foreground">
+              No Go packages found.
+            </p>
+          </BlurFade>
+        )}
+      </section>
+
+      <footer className="mt-auto pt-16 pb-8">
+        <BlurFade delay={BLUR_FADE_DELAY * 10}>
+          <p className="text-center text-sm text-muted-foreground">
+            Made with <span className="text-red-500">❤️</span> by{' '}
+            <Link
+              href="https://dipak.tech"
+              className="font-medium text-foreground hover:text-blue-500 transition-colors"
+            >
+              Dipak Parmar
+            </Link>{' '}
+            in Canada 🇨🇦
+          </p>
+        </BlurFade>
+      </footer>
+    </main>
+  );
+}

--- a/src/app/(go-pkg-site)/layout.tsx
+++ b/src/app/(go-pkg-site)/layout.tsx
@@ -1,0 +1,15 @@
+import { ReactNode } from 'react';
+import { ThemeProvider } from '@/components/theme-provider';
+import { TooltipProvider } from '@/components/ui/tooltip';
+
+export default function GoPackageLayout({ children }: { children: ReactNode }) {
+  return (
+    <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+      <TooltipProvider delayDuration={0}>
+        <div className="font-sans max-w-2xl mx-auto py-12 sm:py-24 px-6">
+          {children}
+        </div>
+      </TooltipProvider>
+    </ThemeProvider>
+  );
+}

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -214,15 +214,9 @@ export async function fetchGoPackages(): Promise<Repo[]> {
   }
 }
 
-export function buildGoImportMeta(
-  pkgName: string,
-  pkgVersion?: string
-): string {
-  const gitUrl = pkgVersion
-    ? `https://github.com/${GITHUB_USERNAME}/${pkgName}/releases/tag/${pkgVersion}`
-    : `https://github.com/${GITHUB_USERNAME}/${pkgName}`;
-
-  return `go.pkg.dipak.io/${pkgName} git ${gitUrl}`;
+export function buildGoImportMeta(pkgName: string): string {
+  // go-import meta tag must always use the repository root URL per Go vanity import spec
+  return `go.pkg.dipak.io/${pkgName} git https://github.com/${GITHUB_USERNAME}/${pkgName}`;
 }
 
 export function getGitHubUrl(pkgName: string): string {

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -1,0 +1,230 @@
+export interface RepoOwner {
+  login: string;
+  id: number;
+  avatar_url: string;
+  html_url: string;
+  type: string;
+}
+
+export interface RepoLicense {
+  key: string;
+  name: string;
+  spdx_id: string;
+  url: string;
+}
+
+export interface Repo {
+  id: number;
+  name: string;
+  full_name: string;
+  private: boolean;
+  owner: RepoOwner;
+  html_url: string;
+  description: string | null;
+  fork: boolean;
+  url: string;
+  language: string | null;
+  stargazers_count: number;
+  watchers_count: number;
+  forks_count: number;
+  topics?: string[] | null;
+  license: RepoLicense | null;
+  visibility: string;
+  default_branch: string;
+}
+
+export interface RepoSearchResponse {
+  total_count: number;
+  incomplete_results: boolean;
+  items?: Repo[] | null;
+}
+
+const GITHUB_USERNAME = 'dipakparmar';
+const MAX_RETRIES = 3;
+const INITIAL_RETRY_DELAY = 1000;
+const CACHE_TTL = 3600 * 1000; // 1 hour in milliseconds
+const STALE_TTL = 24 * 3600 * 1000; // 24 hours - serve stale if fresh fails
+
+// In-memory cache with stale-while-revalidate
+interface CacheEntry<T> {
+  data: T;
+  timestamp: number;
+}
+
+const cache = new Map<string, CacheEntry<unknown>>();
+
+function getCached<T>(key: string): { data: T; isStale: boolean } | null {
+  const entry = cache.get(key) as CacheEntry<T> | undefined;
+  if (!entry) return null;
+
+  const age = Date.now() - entry.timestamp;
+  const isStale = age > CACHE_TTL;
+  const isExpired = age > STALE_TTL;
+
+  if (isExpired) {
+    cache.delete(key);
+    return null;
+  }
+
+  return { data: entry.data, isStale };
+}
+
+function setCache<T>(key: string, data: T): void {
+  cache.set(key, { data, timestamp: Date.now() });
+}
+
+async function fetchWithRetry(
+  url: string,
+  options: RequestInit & { next?: { revalidate: number } },
+  retries = MAX_RETRIES
+): Promise<Response> {
+  let lastError: Error | null = null;
+
+  for (let attempt = 0; attempt < retries; attempt++) {
+    try {
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), 10000);
+
+      const response = await fetch(url, {
+        ...options,
+        signal: controller.signal
+      });
+
+      clearTimeout(timeoutId);
+
+      // Retry on server errors (502, 503, 504)
+      if (response.status >= 502 && response.status <= 504) {
+        const delay = INITIAL_RETRY_DELAY * Math.pow(2, attempt);
+        console.warn(
+          `GitHub API returned ${response.status}, retrying in ${delay}ms (attempt ${attempt + 1}/${retries})`
+        );
+        await new Promise((resolve) => setTimeout(resolve, delay));
+        continue;
+      }
+
+      return response;
+    } catch (error) {
+      lastError = error as Error;
+
+      if ((error as Error).name === 'AbortError') {
+        console.warn(
+          `GitHub API request timed out (attempt ${attempt + 1}/${retries})`
+        );
+      }
+
+      if (attempt < retries - 1) {
+        const delay = INITIAL_RETRY_DELAY * Math.pow(2, attempt);
+        console.warn(`Retrying GitHub API request in ${delay}ms...`);
+        await new Promise((resolve) => setTimeout(resolve, delay));
+      }
+    }
+  }
+
+  throw lastError || new Error('Failed to fetch from GitHub API');
+}
+
+export async function repoExists(repoName: string): Promise<boolean> {
+  if (!repoName) return false;
+
+  const cacheKey = `repo:${repoName}`;
+  const cached = getCached<boolean>(cacheKey);
+
+  // Return fresh cache immediately
+  if (cached && !cached.isStale) {
+    return cached.data;
+  }
+
+  try {
+    const result = await fetchWithRetry(
+      `https://api.github.com/repos/${GITHUB_USERNAME}/${repoName}`,
+      {
+        headers: {
+          Accept: 'application/vnd.github+json',
+          'User-Agent': 'go.pkg.dipak.io/1.0.0'
+        },
+        next: { revalidate: 3600 }
+      }
+    );
+
+    const exists = result.status === 200;
+    setCache(cacheKey, exists);
+    return exists;
+  } catch (error) {
+    console.error('Failed to check repo existence:', error);
+
+    // Return stale cache if available
+    if (cached) {
+      console.warn(`Serving stale cache for repo: ${repoName}`);
+      return cached.data;
+    }
+
+    return false;
+  }
+}
+
+export async function fetchGoPackages(): Promise<Repo[]> {
+  const cacheKey = 'go-packages';
+  const cached = getCached<Repo[]>(cacheKey);
+
+  // Return fresh cache immediately
+  if (cached && !cached.isStale) {
+    return cached.data;
+  }
+
+  try {
+    const res = await fetchWithRetry(
+      `https://api.github.com/search/repositories?q=user:${GITHUB_USERNAME}+language:Go&type=Repositories`,
+      {
+        headers: {
+          Accept: 'application/vnd.github+json',
+          'User-Agent': 'go.pkg.dipak.io/1.0.0'
+        },
+        next: { revalidate: 3600 }
+      }
+    );
+
+    if (!res.ok) {
+      console.error('Failed to fetch Go packages:', res.status);
+
+      // Return stale cache if available
+      if (cached) {
+        console.warn('Serving stale cache for Go packages');
+        return cached.data;
+      }
+
+      return [];
+    }
+
+    const data: RepoSearchResponse = await res.json();
+    const packages = data?.items || [];
+
+    // Update cache on successful fetch
+    setCache(cacheKey, packages);
+    return packages;
+  } catch (error) {
+    console.error('Failed to fetch Go packages:', error);
+
+    // Return stale cache if available
+    if (cached) {
+      console.warn('Serving stale cache for Go packages');
+      return cached.data;
+    }
+
+    return [];
+  }
+}
+
+export function buildGoImportMeta(
+  pkgName: string,
+  pkgVersion?: string
+): string {
+  const gitUrl = pkgVersion
+    ? `https://github.com/${GITHUB_USERNAME}/${pkgName}/releases/tag/${pkgVersion}`
+    : `https://github.com/${GITHUB_USERNAME}/${pkgName}`;
+
+  return `go.pkg.dipak.io/${pkgName} git ${gitUrl}`;
+}
+
+export function getGitHubUrl(pkgName: string): string {
+  return `https://github.com/${GITHUB_USERNAME}/${pkgName}`;
+}


### PR DESCRIPTION
Introduce new routes and rewrites for go.pkg.dipak.io in next.config.mjs, enable GitHub API connections, and add Go package listing and detail pages with UI components for package info and installation. This supports a custom Go vanity import path and improves package discoverability.