### PR TITLE
feat(blog): improve blog list, search, and post header

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,6 @@ OG_SECRET=your-og-secret-change-in-production
 
 # Sentry error tracking
 # NEXT_PUBLIC_SENTRY_DSN=https://xxx@xxx.ingest.us.sentry.io/xxx
+
+# Enable react-grab MCP browser tool (set to "1" to enable, never in production)
+# NEXT_PUBLIC_REACT_GRAB=1

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -68,6 +68,10 @@ const nextConfig = {
       {
         protocol: 'https',
         hostname: 'avatars.githubusercontent.com'
+      },
+      {
+        protocol: 'https',
+        hostname: 'upload.wikimedia.org'
       }
     ]
   },

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -7,10 +7,10 @@ const ContentSecurityPolicy = `
   script-src 'self' 'unsafe-inline' ${process.env.NODE_ENV === 'development' ? "'unsafe-eval'" : ''} https://www.googletagmanager.com https://static.cloudflareinsights.com https://browser.sentry-cdn.com https://unpkg.com;
   style-src 'self' 'unsafe-inline';
   child-src 'none';
-  frame-src 'none';
+  frame-src 'self' https://www.youtube.com https://youtube.com;
   worker-src 'self' blob:;
   connect-src 'self' https://www.cloudflare.com https://cloudflareinsights.com https://www.google-analytics.com https://analytics.google.com https://*.doubleclick.net https://graph.dipak.io https://api.github.com https://ghcr.io https://registry-1.docker.io https://auth.docker.io https://hub.docker.com https://ct.certkit.io https://*.sentry.io https://stat.ripe.net;
-  img-src 'self' https://github.com https://avatars.githubusercontent.com https://www.google-analytics.com https://*.google.com https://*.google.ca https://*.basemaps.cartocdn.com data:;
+  img-src 'self' https://github.com https://avatars.githubusercontent.com https://www.google-analytics.com https://*.google.com https://*.google.ca https://*.basemaps.cartocdn.com https://upload.wikimedia.org data:;
   media-src 'self';
   font-src 'self' https://fonts.googleapis.com https://fonts.gstatic.com;
   object-src 'none';

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -10,7 +10,7 @@ const ContentSecurityPolicy = `
   frame-src 'self' https://www.youtube.com https://youtube.com;
   worker-src 'self' blob:;
   connect-src 'self' https://www.cloudflare.com https://cloudflareinsights.com https://www.google-analytics.com https://analytics.google.com https://*.doubleclick.net https://graph.dipak.io https://api.github.com https://ghcr.io https://registry-1.docker.io https://auth.docker.io https://hub.docker.com https://ct.certkit.io https://*.sentry.io https://stat.ripe.net;
-  img-src 'self' https://github.com https://avatars.githubusercontent.com https://www.google-analytics.com https://*.google.com https://*.google.ca https://*.basemaps.cartocdn.com https://upload.wikimedia.org data:;
+  img-src 'self' https://github.com https://avatars.githubusercontent.com https://www.google-analytics.com https://*.google.com https://*.google.ca https://*.basemaps.cartocdn.com https://upload.wikimedia.org https://images.unsplash.com data:;
   media-src 'self';
   font-src 'self' https://fonts.googleapis.com https://fonts.gstatic.com;
   object-src 'none';

--- a/src/app/(portfolio-site)/blog/[slug]/page.tsx
+++ b/src/app/(portfolio-site)/blog/[slug]/page.tsx
@@ -1,14 +1,15 @@
-import { notFound } from 'next/navigation';
-import Link from 'next/link';
 import { ArrowLeft, Calendar, Clock, RefreshCw } from 'lucide-react';
+import type { BlogPosting, WithContext } from 'schema-dts';
 import { getAllSlugs, getPostBySlug } from '@/lib/blog';
-import { mdxComponents } from '@/components/mdx-components';
-import { Toc } from '@/components/blog/toc';
-import { JsonLd } from '@/components/seo/json-ld';
-import { personReference } from '@/lib/schema';
+
 import { BlurFade } from '@/components/magicui/blur-fade';
+import { JsonLd } from '@/components/seo/json-ld';
+import Link from 'next/link';
 import type { Metadata } from 'next';
-import type { WithContext, BlogPosting } from 'schema-dts';
+import { Toc } from '@/components/blog/toc';
+import { mdxComponents } from '@/components/mdx-components';
+import { notFound } from 'next/navigation';
+import { personReference } from '@/lib/schema';
 
 interface PostPageProps {
   params: Promise<{ slug: string }>;
@@ -76,16 +77,14 @@ export default async function PostPage({ params }: PostPageProps) {
     <>
       <JsonLd data={postSchema} />
       <Toc entries={toc} />
-      <article className="min-h-dvh">
-        <BlurFade delay={BLUR_FADE_DELAY}>
-          <Link
-            href="/blog"
-            className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors mb-10 group"
-          >
-            <ArrowLeft className="size-3 transition-transform group-hover:-translate-x-0.5" />
-            Back to blog
-          </Link>
-        </BlurFade>
+      <article>
+        <Link
+          href="/blog"
+          className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors mb-8"
+        >
+          <ArrowLeft className="size-3" />
+          Back to blog
+        </Link>
 
         <header className="mb-10">
           <BlurFade delay={BLUR_FADE_DELAY * 2}>

--- a/src/app/(portfolio-site)/blog/[slug]/page.tsx
+++ b/src/app/(portfolio-site)/blog/[slug]/page.tsx
@@ -2,6 +2,7 @@ import type { BlogPosting, WithContext } from 'schema-dts';
 import { getAllSlugs, getPostBySlug } from '@/lib/blog';
 
 import { ArrowLeft } from 'lucide-react';
+import Image from 'next/image';
 import { JsonLd } from '@/components/seo/json-ld';
 import Link from 'next/link';
 import type { Metadata } from 'next';
@@ -125,11 +126,22 @@ export default async function PostPage({ params }: PostPageProps) {
           )}
         </header>
 
-        <BlurFade delay={BLUR_FADE_DELAY * 6}>
-          <div className="blog-prose max-w-none">
-            <Content components={mdxComponents} />
+        {meta.image && (
+          <div className="mb-8">
+            <Image
+              src={meta.image}
+              alt={meta.title}
+              width={768}
+              height={400}
+              className="w-full rounded-lg object-cover"
+              unoptimized
+            />
           </div>
-        </BlurFade>
+        )}
+
+        <div className="blog-prose max-w-none">
+          <Content components={mdxComponents} />
+        </div>
       </article>
     </>
   );

--- a/src/app/(portfolio-site)/blog/[slug]/page.tsx
+++ b/src/app/(portfolio-site)/blog/[slug]/page.tsx
@@ -1,8 +1,7 @@
-import { ArrowLeft, Calendar, Clock, RefreshCw } from 'lucide-react';
 import type { BlogPosting, WithContext } from 'schema-dts';
 import { getAllSlugs, getPostBySlug } from '@/lib/blog';
 
-import { BlurFade } from '@/components/magicui/blur-fade';
+import { ArrowLeft } from 'lucide-react';
 import { JsonLd } from '@/components/seo/json-ld';
 import Link from 'next/link';
 import type { Metadata } from 'next';
@@ -78,71 +77,52 @@ export default async function PostPage({ params }: PostPageProps) {
       <JsonLd data={postSchema} />
       <Toc entries={toc} />
       <article>
-        <Link
-          href="/blog"
-          className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors mb-8"
-        >
-          <ArrowLeft className="size-3" />
-          Back to blog
-        </Link>
-
         <header className="mb-10">
-          <BlurFade delay={BLUR_FADE_DELAY * 2}>
-            <div className="flex gap-2 mb-4">
+          <Link
+            href="/blog"
+            className="inline-flex items-center gap-1 text-xs text-muted-foreground/50 hover:text-muted-foreground transition-colors mb-4"
+          >
+            <ArrowLeft className="size-3" />
+            <span>back to blog list</span>
+          </Link>
+          <h1 className="text-2xl font-bold tracking-tight mb-2">{meta.title}</h1>
+          <div className="flex items-center gap-2.5 text-xs text-muted-foreground/60">
+            <time dateTime={meta.date}>
+              {new Date(meta.date).toLocaleDateString('en-US', {
+                year: 'numeric',
+                month: 'long',
+                day: 'numeric',
+              })}
+            </time>
+            <span>·</span>
+            <span>{meta.readingTime} min read</span>
+            {meta.updated && (
+              <>
+                <span>·</span>
+                <span>
+                  Updated{' '}
+                  {new Date(meta.updated).toLocaleDateString('en-US', {
+                    year: 'numeric',
+                    month: 'long',
+                    day: 'numeric',
+                  })}
+                </span>
+              </>
+            )}
+          </div>
+          {meta.tags.length > 0 && (
+            <div className="flex gap-1.5 mt-3">
               {meta.tags.map((tag) => (
                 <Link
                   key={tag}
                   href={`/blog/tags/${tag}`}
-                  className="text-[0.65rem] uppercase tracking-wider text-muted-foreground/70 hover:text-primary transition-colors"
+                  className="text-xs text-muted-foreground bg-muted px-2 py-0.5 rounded-md hover:text-foreground transition-colors"
                 >
                   {tag}
                 </Link>
               ))}
             </div>
-          </BlurFade>
-
-          <BlurFade delay={BLUR_FADE_DELAY * 3}>
-            <h1 className="text-3xl font-bold tracking-tighter sm:text-4xl leading-tight">
-              {meta.title}
-            </h1>
-          </BlurFade>
-
-          <BlurFade delay={BLUR_FADE_DELAY * 4}>
-            <p className="text-muted-foreground mt-3 text-pretty">
-              {meta.description}
-            </p>
-          </BlurFade>
-
-          <BlurFade delay={BLUR_FADE_DELAY * 5}>
-            <div className="flex items-center gap-4 mt-5 pt-5 border-t border-border">
-              <div className="flex items-center gap-1.5 text-xs text-muted-foreground/60">
-                <Calendar className="size-3" />
-                <time dateTime={meta.date}>
-                  {new Date(meta.date).toLocaleDateString('en-US', {
-                    year: 'numeric',
-                    month: 'long',
-                    day: 'numeric',
-                  })}
-                </time>
-              </div>
-              {meta.updated && (
-                <div className="flex items-center gap-1.5 text-xs text-muted-foreground/60">
-                  <RefreshCw className="size-3" />
-                  <span>
-                    {new Date(meta.updated).toLocaleDateString('en-US', {
-                      year: 'numeric',
-                      month: 'long',
-                      day: 'numeric',
-                    })}
-                  </span>
-                </div>
-              )}
-              <div className="flex items-center gap-1.5 text-xs text-muted-foreground/60">
-                <Clock className="size-3" />
-                <span>{meta.readingTime} min read</span>
-              </div>
-            </div>
-          </BlurFade>
+          )}
         </header>
 
         <BlurFade delay={BLUR_FADE_DELAY * 6}>

--- a/src/app/(portfolio-site)/blog/blog-list.tsx
+++ b/src/app/(portfolio-site)/blog/blog-list.tsx
@@ -1,11 +1,12 @@
 'use client';
 
-import { useState } from 'react';
-import Link from 'next/link';
-import { Tag } from 'lucide-react';
-import { SearchToggle } from '@/components/blog/search-toggle';
 import { BlurFade } from '@/components/magicui/blur-fade';
+import Image from 'next/image';
+import Link from 'next/link';
 import type { PostMeta } from '@/lib/blog';
+import { SearchToggle } from '@/components/blog/search-toggle';
+import { Tag } from 'lucide-react';
+import { useState } from 'react';
 
 interface BlogListProps {
   posts: PostMeta[];
@@ -87,43 +88,46 @@ export function BlogList({ posts }: BlogListProps) {
         </div>
       </BlurFade>
 
-      <div>
-        {filtered.map((post, i) => (
-          <BlurFade key={post.slug} delay={BLUR_FADE_DELAY * 2 + i * 0.05}>
-            <Link
-              href={`/blog/${post.slug}`}
-              className="block py-5 group border-b border-border last:border-none -mx-3 px-3 rounded-lg hover:bg-muted/50 transition-colors"
-            >
-              <div className="flex items-baseline justify-between gap-4">
-                <h2 className="text-base font-medium group-hover:text-primary transition-colors">
-                  {post.title}
-                </h2>
-                <span className="text-xs text-muted-foreground/50 shrink-0 tabular-nums">
+      <div className="divide-y divide-border">
+        {filtered.map((post) => (
+          <Link
+            key={post.slug}
+            href={`/blog/${post.slug}`}
+            className="flex items-start gap-4 py-4 group"
+          >
+            {post.image && (
+              <div className="shrink-0 w-20 self-stretch rounded-md overflow-hidden bg-muted">
+                <Image
+                  src={post.image}
+                  alt={post.title}
+                  width={80}
+                  height={120}
+                  className="w-full h-full object-cover"
+                  unoptimized
+                />
+              </div>
+            )}
+            <div className="flex-1 min-w-0 overflow-hidden">
+              <h2 className="text-base font-medium break-words group-hover:text-primary transition-colors">
+                {post.title}
+              </h2>
+              <p className="text-sm text-muted-foreground mt-1 break-words">
+                {post.description}
+              </p>
+              <div className="flex flex-wrap items-center gap-x-3 gap-y-1 mt-2">
+                <span className="text-xs text-muted-foreground/70">
                   {new Date(post.date).toLocaleDateString('en-US', {
                     year: 'numeric',
-                    month: 'short',
+                    month: 'long',
                     day: 'numeric',
                   })}
                 </span>
-              </div>
-              <p className="text-sm text-muted-foreground mt-1 line-clamp-2 text-pretty">
-                {post.description}
-              </p>
-              <div className="flex items-center gap-3 mt-2">
-                <span className="text-xs text-muted-foreground/50">
+                <span className="text-xs text-muted-foreground/70">
                   {post.readingTime} min read
                 </span>
-                {post.tags.map((tag) => (
-                  <span
-                    key={tag}
-                    className="text-[0.65rem] text-muted-foreground/50 uppercase tracking-wider"
-                  >
-                    {tag}
-                  </span>
-                ))}
               </div>
-            </Link>
-          </BlurFade>
+            </div>
+          </Link>
         ))}
       </div>
 

--- a/src/app/(portfolio-site)/blog/blog-list.tsx
+++ b/src/app/(portfolio-site)/blog/blog-list.tsx
@@ -50,46 +50,31 @@ function pick<T>(arr: T[]): T {
 const BLUR_FADE_DELAY = 0.04;
 
 export function BlogList({ posts }: BlogListProps) {
-  const [query, setQuery] = useState('');
-  const [emptySearchLine] = useState(() => pick(SEARCH_LINES));
   const [emptyBlogLine] = useState(() => pick(EMPTY_LINES));
-
-  const filtered = query
-    ? posts.filter((post) => {
-        const q = query.toLowerCase();
-        return (
-          post.title.toLowerCase().includes(q) ||
-          post.description.toLowerCase().includes(q) ||
-          post.tags.some((tag) => tag.toLowerCase().includes(q))
-        );
-      })
-    : posts;
 
   return (
     <main className="min-h-dvh">
-      <BlurFade delay={BLUR_FADE_DELAY}>
-        <div className="flex items-start justify-between gap-4 mb-10">
-          <div>
-            <h1 className="text-3xl font-bold tracking-tighter">Blog</h1>
-            <p className="text-sm text-muted-foreground mt-1.5 text-pretty">
-              Writings on software engineering, infrastructure, and DevSecOps.
-            </p>
-          </div>
-          <div className="flex items-center gap-1 shrink-0 mt-2">
-            <SearchToggle onSearch={setQuery} />
-            <Link
-              href="/blog/tags"
-              className="p-2 text-muted-foreground hover:text-foreground transition-colors rounded-md hover:bg-muted"
-              aria-label="View all tags"
-            >
-              <Tag className="size-4" />
-            </Link>
-          </div>
+      <div className="flex items-start justify-between gap-4 mb-8">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight">Blog</h1>
+          <p className="text-sm text-muted-foreground mt-1">
+            Writings on software engineering, infrastructure, and DevSecOps.
+          </p>
         </div>
-      </BlurFade>
+        <div className="flex items-center gap-1 shrink-0 mt-1">
+          <SearchToggle posts={posts} />
+          <Link
+            href="/blog/tags"
+            className="p-2 text-muted-foreground hover:text-foreground transition-colors"
+            aria-label="View all tags"
+          >
+            <Tag className="size-4" />
+          </Link>
+        </div>
+      </div>
 
       <div className="divide-y divide-border">
-        {filtered.map((post) => (
+        {posts.map((post) => (
           <Link
             key={post.slug}
             href={`/blog/${post.slug}`}
@@ -131,16 +116,12 @@ export function BlogList({ posts }: BlogListProps) {
         ))}
       </div>
 
-      {filtered.length === 0 && (
-        <BlurFade delay={BLUR_FADE_DELAY * 3}>
-          <div className="py-16 text-center">
-            <p className="text-sm text-muted-foreground italic" suppressHydrationWarning>
-              {query
-                ? emptySearchLine.replace('{{q}}', query)
-                : emptyBlogLine}
-            </p>
-          </div>
-        </BlurFade>
+      {posts.length === 0 && (
+        <div className="py-12 text-center">
+          <p className="text-sm text-muted-foreground italic" suppressHydrationWarning>
+            {emptyBlogLine}
+          </p>
+        </div>
       )}
     </main>
   );

--- a/src/app/(portfolio-site)/blog/layout.tsx
+++ b/src/app/(portfolio-site)/blog/layout.tsx
@@ -1,0 +1,11 @@
+import { ReactNode } from 'react';
+
+export default function BlogLayout({ children }: { children: ReactNode }) {
+  // Break out of parent's max-w-2xl (42rem) to max-w-3xl (48rem)
+  // Negative margin = (48 - 42) / 2 = 3rem each side
+  return (
+    <div className="max-w-3xl -mx-3 px-0">
+      {children}
+    </div>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -383,6 +383,15 @@
 .blog-prose img {
   border-radius: 0.5rem;
   margin: 1.75em 0;
+  max-width: 100%;
+  height: auto;
+}
+
+.blog-prose iframe {
+  border-radius: 0.5rem;
+  margin: 1.75em 0;
+  max-width: 100%;
+  border: 1px solid var(--color-border);
 }
 
 .blog-prose table {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -73,6 +73,9 @@
   }
   html {
     scroll-behavior: smooth;
+    @media (prefers-reduced-motion: reduce) {
+      scroll-behavior: auto;
+    }
   }
   body {
     @apply bg-background text-foreground;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -71,6 +71,9 @@
   * {
     @apply border-border outline-ring/50;
   }
+  html {
+    scroll-behavior: smooth;
+  }
   body {
     @apply bg-background text-foreground;
   }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,12 +1,12 @@
 import './globals.css';
 
 import { Inter, Karla } from 'next/font/google';
-import { GoogleTagManager } from '@next/third-parties/google';
+import { LOGO_URL, ogUrls } from '@/lib/og-config';
 
+import { GoogleTagManager } from '@next/third-parties/google';
 import type { Metadata } from 'next';
 import type { Viewport } from 'next';
 import { cn } from '@/lib/utils';
-import { ogUrls, LOGO_URL } from '@/lib/og-config';
 
 export const viewport: Viewport = {
   width: 'device-width',
@@ -98,14 +98,14 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning className={fontInter.variable}>
       <head>
-        {process.env.NODE_ENV === "development" && (
+        {process.env.NEXT_PUBLIC_REACT_GRAB === "1" && (
           <script
             src="//unpkg.com/react-grab/dist/index.global.js"
             crossOrigin="anonymous"
             async
           />
         )}
-        {process.env.NODE_ENV === "development" && (
+        {process.env.NEXT_PUBLIC_REACT_GRAB === "1" && (
           <script
             src="//unpkg.com/@react-grab/mcp/dist/client.global.js"
             async

--- a/src/components/blog/search-toggle.tsx
+++ b/src/components/blog/search-toggle.tsx
@@ -1,57 +1,82 @@
 'use client';
 
-import { useState, useRef, useEffect } from 'react';
-import { Search, X } from 'lucide-react';
+import {
+  Command,
+  CommandDialog,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@/components/ui/command';
+import { useEffect, useState } from 'react';
+
+import type { PostMeta } from '@/lib/blog';
+import { Search } from 'lucide-react';
+import { useRouter } from 'next/navigation';
 
 interface SearchToggleProps {
-  onSearch: (query: string) => void;
+  posts: PostMeta[];
 }
 
-export function SearchToggle({ onSearch }: SearchToggleProps) {
+export function SearchToggle({ posts }: SearchToggleProps) {
   const [open, setOpen] = useState(false);
-  const [query, setQuery] = useState('');
-  const inputRef = useRef<HTMLInputElement>(null);
+  const router = useRouter();
 
   useEffect(() => {
-    if (open && inputRef.current) {
-      inputRef.current.focus();
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === 'k' && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault();
+        setOpen((prev) => !prev);
+      }
     }
-  }, [open]);
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, []);
 
-  function handleChange(value: string) {
-    setQuery(value);
-    onSearch(value);
-  }
-
-  function handleClose() {
+  function handleSelect(slug: string) {
     setOpen(false);
-    setQuery('');
-    onSearch('');
+    router.push(`/blog/${slug}`);
   }
 
   return (
-    <div className="flex items-center gap-1.5">
-      <div
-        className={`overflow-hidden transition-all duration-200 ease-out ${
-          open ? 'w-48 opacity-100' : 'w-0 opacity-0'
-        }`}
-      >
-        <input
-          ref={inputRef}
-          type="text"
-          value={query}
-          onChange={(e) => handleChange(e.target.value)}
-          placeholder="Search posts..."
-          className="w-full bg-transparent border-b border-muted-foreground/20 text-sm text-foreground placeholder:text-muted-foreground/40 focus:outline-none focus:border-foreground/40 transition-colors py-0.5"
-        />
-      </div>
+    <>
       <button
-        onClick={open ? handleClose : () => setOpen(true)}
-        className="p-2 text-muted-foreground hover:text-foreground transition-colors rounded-md hover:bg-muted"
-        aria-label={open ? 'Close search' : 'Search posts'}
+        onClick={() => setOpen(true)}
+        className="p-2 text-muted-foreground hover:text-foreground transition-colors"
+        aria-label="Search posts"
       >
-        {open ? <X className="size-4" /> : <Search className="size-4" />}
+        <Search className="size-4" />
       </button>
-    </div>
+
+      <CommandDialog
+        open={open}
+        onOpenChange={setOpen}
+        title="Search posts"
+        description="Search blog posts by title, description, or tag"
+      >
+        <Command>
+          <CommandInput placeholder="Search posts..." />
+          <CommandList>
+            <CommandEmpty>No posts found.</CommandEmpty>
+            <CommandGroup heading="Posts">
+              {posts.map((post) => (
+                <CommandItem
+                  key={post.slug}
+                  value={`${post.title} ${post.description} ${post.tags.join(' ')}`}
+                  onSelect={() => handleSelect(post.slug)}
+                  className="flex-col items-start"
+                >
+                  <span className="font-medium">{post.title}</span>
+                  <span className="text-muted-foreground text-xs truncate w-full">
+                    {post.description}
+                  </span>
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </CommandDialog>
+    </>
   );
 }

--- a/src/components/blog/toc.tsx
+++ b/src/components/blog/toc.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef } from 'react';
 
 import type { TocEntry } from '@/lib/blog';
 
@@ -9,14 +9,24 @@ interface TocProps {
 }
 
 export function Toc({ entries }: TocProps) {
-  const [activeId, setActiveId] = useState<string>('');
+  const linkRefs = useRef<Map<string, HTMLAnchorElement>>(new Map());
 
   useEffect(() => {
+    const map = linkRefs.current;
+
+    function activate(id: string) {
+      for (const [entryId, el] of map) {
+        const isActive = entryId === id;
+        el.style.color = isActive ? 'var(--foreground)' : '';
+        el.style.fontWeight = isActive ? '500' : '';
+      }
+    }
+
     const observer = new IntersectionObserver(
       (observedEntries) => {
         for (const entry of observedEntries) {
           if (entry.isIntersecting) {
-            setActiveId(entry.target.id);
+            activate(entry.target.id);
           }
         }
       },
@@ -27,7 +37,7 @@ export function Toc({ entries }: TocProps) {
     headings.forEach((el) => observer.observe(el));
 
     return () => observer.disconnect();
-  }, []);
+  }, [entries]);
 
   if (entries.length === 0) return null;
 
@@ -36,31 +46,23 @@ export function Toc({ entries }: TocProps) {
       <p className="text-xs font-medium text-muted-foreground mb-3 uppercase tracking-wider">
         On this page
       </p>
-      <ul className="relative space-y-0.5 text-[0.8rem] border-l border-border">
-        {entries.map((entry) => {
-          const isActive = activeId === entry.id;
-          return (
-            <li
-              key={entry.id}
-              className="relative"
+      <ul className="space-y-1.5 text-sm">
+        {entries.map((entry) => (
+          <li
+            key={entry.id}
+            style={{ paddingLeft: `${(entry.level - 2) * 12}px` }}
+          >
+            <a
+              href={`#${entry.id}`}
+              ref={(el) => {
+                if (el) linkRefs.current.set(entry.id, el);
+              }}
+              className="block py-0.5 transition-colors text-muted-foreground/70 hover:text-foreground"
             >
-              {isActive && (
-                <span className="absolute left-0 top-0 bottom-0 w-px bg-foreground -translate-x-px" />
-              )}
-              <a
-                href={`#${entry.id}`}
-                className={`block py-1 transition-colors ${
-                  isActive
-                    ? 'text-foreground'
-                    : 'text-muted-foreground/50 hover:text-muted-foreground'
-                }`}
-                style={{ paddingLeft: `${8 + (entry.level - 2) * 12}px` }}
-              >
-                {entry.text}
-              </a>
-            </li>
-          );
-        })}
+              {entry.text}
+            </a>
+          </li>
+        ))}
       </ul>
     </nav>
   );

--- a/src/components/blog/toc.tsx
+++ b/src/components/blog/toc.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+
 import type { TocEntry } from '@/lib/blog';
 
 interface TocProps {
@@ -31,8 +32,8 @@ export function Toc({ entries }: TocProps) {
   if (entries.length === 0) return null;
 
   return (
-    <nav className="hidden xl:block fixed right-[max(2rem,calc(50%-28rem-12rem))] top-24 w-56">
-      <p className="text-[0.65rem] font-medium text-muted-foreground/50 mb-4 uppercase tracking-widest">
+    <nav className="hidden xl:block fixed right-[max(2rem,calc(50%-24rem-15rem))] top-24 w-56">
+      <p className="text-xs font-medium text-muted-foreground mb-3 uppercase tracking-wider">
         On this page
       </p>
       <ul className="relative space-y-0.5 text-[0.8rem] border-l border-border">


### PR DESCRIPTION
## Summary
- Redesign the blog list and post header for a cleaner, tighter layout and better metadata presentation.
- Replace inline blog search with a command palette (CMD/CTRL+K) that routes to posts.
- Add cover image support for blog posts, plus improved TOC active state and smooth scroll.

## Changes
- Blog list now uses image thumbnails, simplified metadata, and a new command palette search ().
- Post page header simplified; optional cover image rendered with .
- TOC active styling now handled via IntersectionObserver refs; layout widened via a blog-specific layout.
- Global CSS tweaks for smooth scroll and better image/iframe rendering.
- CSP updates to allow YouTube frames and new image hosts; optional  flag in .

## Testing
- Not run (UI-only changes)
