### PR TITLE
feat(blog): dynamic OG image generation

### DIFF
--- a/src/app/(portfolio-site)/blog/[slug]/page.tsx
+++ b/src/app/(portfolio-site)/blog/[slug]/page.tsx
@@ -10,6 +10,7 @@ import { Toc } from '@/components/blog/toc';
 import { mdxComponents } from '@/components/mdx-components';
 import { notFound } from 'next/navigation';
 import { personReference } from '@/lib/schema';
+import { ogUrls } from '@/lib/og-config';
 
 interface PostPageProps {
   params: Promise<{ slug: string }>;
@@ -38,7 +39,15 @@ export async function generateMetadata({
         publishedTime: meta.date,
         modifiedTime: meta.updated,
         tags: meta.tags,
-        ...(meta.image && { images: [meta.image] }),
+        images: [
+          ogUrls.blog({
+            title: meta.title,
+            description: meta.description,
+            tags: meta.tags.join(','),
+            date: meta.date,
+            readingTime: String(meta.readingTime),
+          }),
+        ],
       },
     };
   } catch {

--- a/src/app/(portfolio-site)/blog/[slug]/page.tsx
+++ b/src/app/(portfolio-site)/blog/[slug]/page.tsx
@@ -10,6 +10,7 @@ import { Toc } from '@/components/blog/toc';
 import { mdxComponents } from '@/components/mdx-components';
 import { notFound } from 'next/navigation';
 import { personReference } from '@/lib/schema';
+import { headers } from 'next/headers';
 import { ogUrls } from '@/lib/og-config';
 
 interface PostPageProps {
@@ -26,6 +27,10 @@ export async function generateMetadata({
   const { slug } = await params;
   try {
     const { meta } = await getPostBySlug(slug);
+    const headersList = await headers();
+    const host = headersList.get('host') ?? 'dipak.tech';
+    const proto = host.startsWith('localhost') || host.startsWith('127.0.0.1') ? 'http' : 'https';
+    const currentBaseUrl = `${proto}://${host}`;
     return {
       title: `${meta.title} | Dipak Parmar`,
       description: meta.description,
@@ -46,6 +51,7 @@ export async function generateMetadata({
             tags: meta.tags.join(','),
             date: meta.date,
             readingTime: String(meta.readingTime),
+            baseUrl: currentBaseUrl,
           }),
         ],
       },

--- a/src/app/api/og/blog/route.tsx
+++ b/src/app/api/og/blog/route.tsx
@@ -8,9 +8,10 @@ import {
   OGWrapper,
   createErrorResponse,
   createOGResponse,
+  gradients,
+  siteConfig,
   verifyOGRequest,
 } from '@/lib/og-utils';
-import { gradients, siteConfig } from '@/lib/og-config';
 
 import { NextRequest } from 'next/server';
 
@@ -62,8 +63,10 @@ function BlogOG({
               lineHeight: 1.15,
               margin: 0,
               maxWidth: '900px',
+              display: '-webkit-box',
+              WebkitLineClamp: 2,
+              WebkitBoxOrient: 'vertical',
               overflow: 'hidden',
-              maxHeight: '130px',
               textShadow: '0 2px 10px rgba(0,0,0,0.2)',
             }}
           >
@@ -76,17 +79,19 @@ function BlogOG({
               margin: 0,
               maxWidth: '820px',
               lineHeight: 1.4,
+              display: '-webkit-box',
+              WebkitLineClamp: 2,
+              WebkitBoxOrient: 'vertical',
               overflow: 'hidden',
-              maxHeight: '74px',
             }}
           >
             {description}
           </p>
           {tags.length > 0 && (
             <div style={{ display: 'flex', gap: '10px' }}>
-              {tags.slice(0, 5).map((tag) => (
+              {tags.slice(0, 5).map((tag, i) => (
                 <div
-                  key={tag}
+                  key={`${tag}-${i}`}
                   style={{
                     background: 'rgba(251,146,60,0.15)',
                     border: '1px solid rgba(251,146,60,0.4)',

--- a/src/app/api/og/blog/route.tsx
+++ b/src/app/api/og/blog/route.tsx
@@ -1,0 +1,195 @@
+import {
+  Avatar,
+  Badge,
+  ContentContainer,
+  GradientAccent,
+  GridPattern,
+  Header,
+  OGWrapper,
+  createErrorResponse,
+  createOGResponse,
+  verifyOGRequest,
+} from '@/lib/og-utils';
+import { gradients, siteConfig } from '@/lib/og-config';
+
+import { NextRequest } from 'next/server';
+
+function BlogOG({
+  title,
+  description,
+  tags,
+  date,
+  readingTime,
+}: {
+  title: string;
+  description: string;
+  tags: string[];
+  date: string;
+  readingTime: string;
+}) {
+  const formattedDate = date
+    ? new Date(date).toLocaleDateString('en-US', {
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+      })
+    : '';
+
+  return (
+    <OGWrapper gradient={gradients.blog}>
+      <GridPattern />
+      <GradientAccent color="rgba(251,146,60,0.25)" size={350} top={-80} right={-80} />
+      <ContentContainer>
+        {/* Header row */}
+        <Header
+          badge={
+            <Badge
+              icon="✍️"
+              text="Blog"
+              gradient="linear-gradient(135deg, rgba(251,146,60,0.3) 0%, rgba(234,88,12,0.3) 100%)"
+            />
+          }
+          domain={siteConfig.blog.domain}
+        />
+
+        {/* Title + description + tags */}
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
+          <h1
+            style={{
+              fontSize: 56,
+              fontWeight: 700,
+              color: 'white',
+              lineHeight: 1.15,
+              margin: 0,
+              maxWidth: '900px',
+              overflow: 'hidden',
+              maxHeight: '130px',
+              textShadow: '0 2px 10px rgba(0,0,0,0.2)',
+            }}
+          >
+            {title}
+          </h1>
+          <p
+            style={{
+              fontSize: 26,
+              color: 'rgba(255,255,255,0.75)',
+              margin: 0,
+              maxWidth: '820px',
+              lineHeight: 1.4,
+              overflow: 'hidden',
+              maxHeight: '74px',
+            }}
+          >
+            {description}
+          </p>
+          {tags.length > 0 && (
+            <div style={{ display: 'flex', gap: '10px' }}>
+              {tags.slice(0, 5).map((tag) => (
+                <div
+                  key={tag}
+                  style={{
+                    background: 'rgba(251,146,60,0.15)',
+                    border: '1px solid rgba(251,146,60,0.4)',
+                    color: 'rgba(251,146,60,1)',
+                    borderRadius: 999,
+                    padding: '6px 16px',
+                    fontSize: 20,
+                    display: 'flex',
+                  }}
+                >
+                  {tag}
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* Footer row */}
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+          }}
+        >
+          {/* Reading time + date */}
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: '12px',
+              color: 'rgba(255,255,255,0.5)',
+              fontSize: 22,
+            }}
+          >
+            {readingTime && <span>⏱ {readingTime} min read</span>}
+            {readingTime && formattedDate && (
+              <span style={{ display: 'flex' }}>·</span>
+            )}
+            {formattedDate && <span style={{ display: 'flex' }}>{formattedDate}</span>}
+          </div>
+          {/* Avatar + name */}
+          <div style={{ display: 'flex', alignItems: 'center', gap: '16px' }}>
+            <Avatar size={48} />
+            <span style={{ color: 'rgba(255,255,255,0.7)', fontSize: 22, display: 'flex' }}>
+              Dipak Parmar
+            </span>
+          </div>
+        </div>
+      </ContentContainer>
+    </OGWrapper>
+  );
+}
+
+export async function GET(request: NextRequest) {
+  const verification = await verifyOGRequest(request);
+  if (!verification.valid) {
+    return new Response(verification.error || 'Unauthorized', { status: 401 });
+  }
+
+  const { searchParams } = new URL(request.url);
+  const defaults = siteConfig.blog.defaults;
+
+  const title = searchParams.get('title') || defaults.title;
+  const description = searchParams.get('description') || defaults.description;
+  const tagsParam = searchParams.get('tags') || '';
+  const date = searchParams.get('date') || '';
+  const readingTime = searchParams.get('readingTime') || '';
+
+  const tags = tagsParam ? tagsParam.split(',').map((t) => t.trim()).filter(Boolean) : [];
+
+  const allText = [
+    title,
+    description,
+    ...tags,
+    readingTime ? `${readingTime} min read` : '',
+    date
+      ? new Date(date).toLocaleDateString('en-US', {
+          year: 'numeric',
+          month: 'long',
+          day: 'numeric',
+        })
+      : '',
+    'Blog',
+    'Dipak Parmar',
+    'dipak.tech',
+  ]
+    .filter(Boolean)
+    .join('');
+
+  const element = (
+    <BlogOG
+      title={title}
+      description={description}
+      tags={tags}
+      date={date}
+      readingTime={readingTime}
+    />
+  );
+
+  try {
+    return await createOGResponse(element, allText);
+  } catch (e: unknown) {
+    return createErrorResponse(e instanceof Error ? e.message : 'Unknown error');
+  }
+}

--- a/src/lib/og-config.ts
+++ b/src/lib/og-config.ts
@@ -81,9 +81,6 @@ export const siteConfig = {
     defaults: {
       title: 'Blog',
       description: 'Writing about DevSecOps, Kubernetes, and developer tools.',
-      tags: '',
-      date: '',
-      readingTime: '',
     },
   },
 } as const;

--- a/src/lib/og-config.ts
+++ b/src/lib/og-config.ts
@@ -74,6 +74,18 @@ export const siteConfig = {
       handle: '@iamdipakparmar',
     },
   },
+  blog: {
+    domain: 'dipak.tech',
+    baseUrl: 'https://dipak.tech',
+    ogPath: '/api/og/blog',
+    defaults: {
+      title: 'Blog',
+      description: 'Writing about DevSecOps, Kubernetes, and developer tools.',
+      tags: '',
+      date: '',
+      readingTime: '',
+    },
+  },
 } as const;
 
 export type SiteKey = keyof typeof siteConfig;
@@ -85,6 +97,7 @@ export const gradients = {
   'go-pkg': 'linear-gradient(145deg, #00ADD8 0%, #007d9c 100%)',
   'container-registry': 'linear-gradient(145deg, #003f5c 0%, #2496ED 100%)',
   links: 'linear-gradient(145deg, #ec4899 0%, #8b5cf6 50%, #6366f1 100%)',
+  blog: 'linear-gradient(145deg, #0f172a 0%, #1e293b 100%)',
 } as const;
 
 export type GradientKey = keyof typeof gradients;
@@ -182,5 +195,23 @@ export const ogUrls = {
       title: params.title || config.defaults.title,
       handle: params.handle || config.defaults.handle,
     });
+  },
+
+  blog: (params: {
+    title?: string;
+    description?: string;
+    tags?: string;
+    date?: string;
+    readingTime?: string;
+  } = {}) => {
+    const config = siteConfig.blog;
+    const p: Record<string, string> = {
+      title: params.title || config.defaults.title,
+      description: params.description || config.defaults.description,
+    };
+    if (params.tags) p.tags = params.tags;
+    if (params.date) p.date = params.date;
+    if (params.readingTime) p.readingTime = params.readingTime;
+    return buildOGUrl(config.baseUrl, config.ogPath, p);
   },
 };

--- a/src/lib/og-config.ts
+++ b/src/lib/og-config.ts
@@ -200,8 +200,10 @@ export const ogUrls = {
     tags?: string;
     date?: string;
     readingTime?: string;
+    baseUrl?: string;
   } = {}) => {
     const config = siteConfig.blog;
+    const resolvedBaseUrl = params.baseUrl || config.baseUrl;
     const p: Record<string, string> = {
       title: params.title || config.defaults.title,
       description: params.description || config.defaults.description,
@@ -209,6 +211,6 @@ export const ogUrls = {
     if (params.tags) p.tags = params.tags;
     if (params.date) p.date = params.date;
     if (params.readingTime) p.readingTime = params.readingTime;
-    return buildOGUrl(config.baseUrl, config.ogPath, p);
+    return buildOGUrl(resolvedBaseUrl, config.ogPath, p);
   },
 };

--- a/src/lib/og-utils.tsx
+++ b/src/lib/og-utils.tsx
@@ -30,6 +30,7 @@ export const domains: Record<SiteType, string> = {
   'go-pkg': siteConfig.goPkg.domain,
   'container-registry': siteConfig.containerRegistry.domain,
   links: siteConfig.links.domain,
+  blog: siteConfig.blog.domain,
 };
 
 // =============================================================================


### PR DESCRIPTION
## Summary

- Adds `/api/og/blog` route that generates 1200×630 Open Graph images for blog posts with title, description, amber tag pills, reading time, date, and author footer
- Extends `og-config.ts` with `gradients.blog`, `siteConfig.blog`, and `ogUrls.blog()` following the existing OG image pattern
- Wires the signed OG image URL into `generateMetadata` for all blog posts; uses `headers()` to resolve the current request host so the URL is correct across all hosted domains

🤖 Generated with [Claude Code](https://claude.com/claude-code)