### PR TITLE
feat(osint): add Security Posture, Site Identity, and Threat & History sections

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -57,6 +57,7 @@
       "devDependencies": {
         "@react-grab/mcp": "^0.1.21",
         "@tailwindcss/typography": "^0.5.13",
+        "@types/bun": "^1.3.13",
         "@types/geojson": "^7946.0.16",
         "@types/leaflet": "^1.9.21",
         "@types/leaflet-draw": "^1.0.13",
@@ -687,6 +688,8 @@
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 
+    "@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
+
     "@types/connect": ["@types/connect@3.4.38", "", { "dependencies": { "@types/node": "*" } }, "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug=="],
 
     "@types/debug": ["@types/debug@4.1.12", "", { "dependencies": { "@types/ms": "*" } }, "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ=="],
@@ -942,6 +945,8 @@
     "browserslist": ["browserslist@4.28.1", "", { "dependencies": { "baseline-browser-mapping": "^2.9.0", "caniuse-lite": "^1.0.30001759", "electron-to-chromium": "^1.5.263", "node-releases": "^2.0.27", "update-browserslist-db": "^1.2.0" }, "bin": { "browserslist": "cli.js" } }, "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA=="],
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
+
+    "bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
 
     "bundle-name": ["bundle-name@4.1.0", "", { "dependencies": { "run-applescript": "^7.0.0" } }, "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q=="],
 

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
   "devDependencies": {
     "@react-grab/mcp": "^0.1.21",
     "@tailwindcss/typography": "^0.5.13",
+    "@types/bun": "^1.3.13",
     "@types/geojson": "^7946.0.16",
     "@types/leaflet": "^1.9.21",
     "@types/leaflet-draw": "^1.0.13",

--- a/src/app/api/osint/dns/route.ts
+++ b/src/app/api/osint/dns/route.ts
@@ -52,7 +52,10 @@ export async function GET(request: Request) {
         },
       )
     }
-    const results = await Promise.allSettled(RECORD_TYPES.map((type) => queryDNS(normalized, type)))
+    const [mainResults, dmarcResult] = await Promise.all([
+      Promise.allSettled(RECORD_TYPES.map((type) => queryDNS(normalized, type))),
+      queryDNS(`_dmarc.${normalized}`, "TXT").catch(() => null),
+    ])
 
     const records: Record<RecordType, string[]> = {
       A: [],
@@ -64,14 +67,15 @@ export async function GET(request: Request) {
       SOA: [],
     }
 
-    results.forEach((result, index) => {
+    mainResults.forEach((result, index) => {
       const type = RECORD_TYPES[index]
       if (result.status === "fulfilled" && result.value.Answer) {
         records[type] = result.value.Answer.map((record) => record.data)
       }
     })
 
-    const emailSecurity = parseEmailSecurity(records.TXT)
+    const dmarcTxt = dmarcResult?.Answer?.map((r) => r.data) ?? []
+    const emailSecurity = parseEmailSecurity([...records.TXT, ...dmarcTxt])
 
     const payload = {
       target: normalized,

--- a/src/app/api/osint/dns/route.ts
+++ b/src/app/api/osint/dns/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server"
 import { buildRateLimitHeaders, checkRateLimit, getCached, getClientId, setCached } from "@/lib/osint-cache"
 import { captureAPIError } from "@/lib/sentry-utils"
+import { parseEmailSecurity } from "@/lib/email-security"
 
 const RECORD_TYPES = ["A", "AAAA", "CNAME", "MX", "NS", "TXT", "SOA"] as const
 const RESPONSE_CACHE_TTL = 5 * 60 * 1000
@@ -70,9 +71,12 @@ export async function GET(request: Request) {
       }
     })
 
+    const emailSecurity = parseEmailSecurity(records.TXT)
+
     const payload = {
       target: normalized,
       records,
+      emailSecurity,
     }
 
     setCached(cacheKey, payload, RESPONSE_CACHE_TTL)

--- a/src/app/api/osint/http/route.ts
+++ b/src/app/api/osint/http/route.ts
@@ -10,6 +10,7 @@ import { captureAPIError } from "@/lib/sentry-utils"
 import { detectWAF } from "@/lib/waf-detector"
 import { detectTechStack } from "@/lib/tech-stack"
 import { parseSocialTags } from "@/lib/social-tags"
+import { signImageUrl } from "@/lib/osint-image-sign"
 import type { CookieInfo, RedirectHop } from "@/lib/osint-types"
 
 const HEADER_ALLOWLIST = [
@@ -89,6 +90,9 @@ export async function GET(request: Request) {
     const waf = detectWAF(allHeaders)
     const techStack = detectTechStack(allHeaders, html)
     const socialTags = parseSocialTags(html)
+    if (socialTags.og.image) {
+      socialTags.og.imageToken = await signImageUrl(socialTags.og.image)
+    }
 
     const payload = {
       url: response.url,

--- a/src/app/api/osint/http/route.ts
+++ b/src/app/api/osint/http/route.ts
@@ -1,52 +1,49 @@
 import { NextResponse } from "next/server"
-import { buildRateLimitHeaders, checkRateLimit, getCached, getClientId, setCached } from "@/lib/osint-cache"
+import {
+  buildRateLimitHeaders,
+  checkRateLimit,
+  getCached,
+  getClientId,
+  setCached,
+} from "@/lib/osint-cache"
 import { captureAPIError } from "@/lib/sentry-utils"
+import { detectWAF } from "@/lib/waf-detector"
+import { detectTechStack } from "@/lib/tech-stack"
+import { parseSocialTags } from "@/lib/social-tags"
+import type { CookieInfo, RedirectHop } from "@/lib/osint-types"
 
 const HEADER_ALLOWLIST = [
-  "server",
-  "content-type",
-  "content-length",
-  "cache-control",
-  "x-powered-by",
-  "x-served-by",
-  "x-cache",
-  "x-cache-hits",
-  "cf-ray",
-  "cf-cache-status",
-  "via",
-  "strict-transport-security",
-  "content-security-policy",
-  "x-frame-options",
-  "referrer-policy",
-  "permissions-policy",
+  "server", "content-type", "content-length", "cache-control",
+  "x-powered-by", "x-served-by", "x-cache", "x-cache-hits",
+  "cf-ray", "cf-cache-status", "via", "strict-transport-security",
+  "content-security-policy", "x-frame-options", "referrer-policy",
+  "permissions-policy", "x-vercel-id", "x-vercel-cache",
+  "x-amz-cf-id", "x-akamai-transformed", "x-sucuri-id",
+  "x-shopid", "x-github-request-id", "x-nf-request-id",
 ]
 
 const SECURITY_HEADERS = [
-  "strict-transport-security",
-  "content-security-policy",
-  "x-frame-options",
-  "referrer-policy",
-  "permissions-policy",
+  "strict-transport-security", "content-security-policy",
+  "x-frame-options", "referrer-policy", "permissions-policy",
 ]
+
 const RESPONSE_CACHE_TTL = 5 * 60 * 1000
 const RATE_LIMIT = 40
 const RATE_WINDOW_MS = 60 * 1000
+const HTML_CAP = 100_000
+const MAX_REDIRECTS = 10
+const FETCH_TIMEOUT_MS = 8000
 
 export async function GET(request: Request) {
   try {
     const { searchParams } = new URL(request.url)
     const target = searchParams.get("target")
-
-    if (!target) {
-      return NextResponse.json({ error: "Target parameter is required" }, { status: 400 })
-    }
+    if (!target) return NextResponse.json({ error: "Target parameter is required" }, { status: 400 })
 
     const normalized = target.trim()
     const cacheKey = `http:${normalized.toLowerCase()}`
     const cached = getCached<Record<string, unknown>>(cacheKey)
-    if (cached) {
-      return NextResponse.json(cached, { headers: { "X-Cache": "HIT" } })
-    }
+    if (cached) return NextResponse.json(cached, { headers: { "X-Cache": "HIT" } })
 
     const clientId = getClientId(request.headers)
     const rateInfo = checkRateLimit(clientId, RATE_LIMIT, RATE_WINDOW_MS)
@@ -62,112 +59,150 @@ export async function GET(request: Request) {
         },
       )
     }
-    const urls = normalized.includes("://")
+
+    const startUrls = normalized.includes("://")
       ? [normalized]
       : [`https://${normalized}`, `http://${normalized}`]
 
-    const response = await fetchFirstSuccessful(urls)
-    if (!response) {
-      return NextResponse.json({ error: "Unable to reach target" }, { status: 502 })
-    }
+    const result = await fetchWithChain(startUrls)
+    if (!result) return NextResponse.json({ error: "Unable to reach target" }, { status: 502 })
 
-    const text = await readLimitedBody(response, 160_000)
-    const titleMatch = text.match(/<title[^>]*>([^<]*)<\/title>/i)
+    const { response, chain, allHeaders } = result
+    const html = await readLimitedBody(response, HTML_CAP)
+
+    const titleMatch = html.match(/<title[^>]*>([^<]*)<\/title>/i)
     const title = titleMatch ? titleMatch[1].trim() : null
 
     const headers: Record<string, string> = {}
     const securityHeaders: Record<string, string> = {}
 
-    HEADER_ALLOWLIST.forEach((header) => {
-      const value = response.headers.get(header)
-      if (value) {
-        headers[header] = value
-      }
+    HEADER_ALLOWLIST.forEach((h) => {
+      const v = allHeaders[h]
+      if (v) headers[h] = v
+    })
+    SECURITY_HEADERS.forEach((h) => {
+      const v = allHeaders[h]
+      if (v) securityHeaders[h] = v
     })
 
-    SECURITY_HEADERS.forEach((header) => {
-      const value = response.headers.get(header)
-      if (value) {
-        securityHeaders[header] = value
-      }
-    })
+    const cookies = parseCookies(response.headers)
+    const waf = detectWAF(allHeaders)
+    const techStack = detectTechStack(allHeaders, html)
+    const socialTags = parseSocialTags(html)
 
     const payload = {
       url: response.url,
       status: response.status,
       ok: response.ok,
-      redirected: response.redirected,
+      redirected: chain.length > 1,
       title,
       headers,
       securityHeaders,
+      cookies,
+      redirectChain: chain,
+      waf,
+      techStack,
+      socialTags,
     }
 
     setCached(cacheKey, payload, RESPONSE_CACHE_TTL)
-
     return NextResponse.json(payload, {
-      headers: {
-        "X-Cache": "MISS",
-        ...buildRateLimitHeaders(RATE_LIMIT, rateInfo),
-      },
+      headers: { "X-Cache": "MISS", ...buildRateLimitHeaders(RATE_LIMIT, rateInfo) },
     })
   } catch (error) {
     return captureAPIError(error, request, 500, { operation: "http_fingerprint" })
   }
 }
 
-async function fetchFirstSuccessful(urls: string[]) {
-  for (const url of urls) {
+async function fetchWithChain(startUrls: string[]) {
+  for (const startUrl of startUrls) {
     try {
-      const controller = new AbortController()
-      const timeout = setTimeout(() => controller.abort(), 8000)
+      const chain: RedirectHop[] = []
+      let currentUrl = startUrl
+      const allHeaders: Record<string, string> = {}
 
-      const response = await fetch(url, {
-        method: "GET",
-        redirect: "follow",
-        signal: controller.signal,
-        headers: {
-          "User-Agent": "dipak.tech-osint/1.0",
-          Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
-        },
-      })
+      for (let i = 0; i < MAX_REDIRECTS; i++) {
+        const controller = new AbortController()
+        const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS)
+        const hopStart = Date.now()
 
-      clearTimeout(timeout)
+        const response = await fetch(currentUrl, {
+          method: "GET",
+          redirect: "manual",
+          signal: controller.signal,
+          headers: {
+            "User-Agent": "dipak.tech-osint/1.0",
+            Accept: "text/html,application/xhtml+xml,*/*;q=0.8",
+          },
+        })
+        clearTimeout(timeout)
 
-      return response
-    } catch (error) {
-      if (error instanceof Error && error.name !== "AbortError") {
-        continue
+        const latencyMs = Date.now() - hopStart
+        chain.push({ url: currentUrl, status: response.status, latencyMs })
+
+        response.headers.forEach((value, key) => {
+          if (!allHeaders[key.toLowerCase()]) allHeaders[key.toLowerCase()] = value
+        })
+
+        if (response.status >= 300 && response.status < 400) {
+          const location = response.headers.get("location")
+          if (!location) break
+          currentUrl = new URL(location, currentUrl).href
+          continue
+        }
+
+        return { response, chain, allHeaders }
       }
+    } catch {
+      continue
     }
   }
-
   return null
+}
+
+function parseCookies(headers: Headers): CookieInfo[] {
+  const raw = headers.getSetCookie?.() ?? [headers.get("set-cookie")].filter(Boolean) as string[]
+  return raw.map((cookie) => {
+    const parts = cookie.split(";").map((p) => p.trim())
+    const [nameValue] = parts
+    const eqIdx = nameValue.indexOf("=")
+    const name = eqIdx >= 0 ? nameValue.slice(0, eqIdx).trim() : nameValue.trim()
+    const attrs = parts.slice(1)
+    const attr = (key: string) =>
+      attrs.find((a) => a.toLowerCase().startsWith(key.toLowerCase()))
+
+    const sameSiteRaw = attr("samesite=")?.split("=")?.[1]?.trim() ?? null
+    const sameSite =
+      sameSiteRaw === "Strict" || sameSiteRaw === "Lax" || sameSiteRaw === "None"
+        ? sameSiteRaw
+        : null
+
+    return {
+      name,
+      domain: attr("domain=")?.split("=")?.[1]?.trim() ?? null,
+      path: attr("path=")?.split("=")?.[1]?.trim() ?? null,
+      secure: attrs.some((a) => a.toLowerCase() === "secure"),
+      httpOnly: attrs.some((a) => a.toLowerCase() === "httponly"),
+      sameSite,
+      expires: attr("expires=")?.split("=")?.slice(1)?.join("=")?.trim() ?? null,
+    }
+  })
 }
 
 async function readLimitedBody(response: Response, maxBytes: number) {
   const reader = response.body?.getReader()
   if (!reader) return ""
-
   const chunks: Uint8Array[] = []
   let received = 0
-
   while (received < maxBytes) {
     const { done, value } = await reader.read()
     if (done || !value) break
-
     chunks.push(value)
     received += value.length
-
     if (received >= maxBytes) break
   }
-
-  const total = chunks.reduce((acc, chunk) => acc + chunk.length, 0)
-  const buffer = new Uint8Array(total)
+  const buffer = new Uint8Array(chunks.reduce((a, c) => a + c.length, 0))
   let offset = 0
-  for (const chunk of chunks) {
-    buffer.set(chunk, offset)
-    offset += chunk.length
-  }
-
+  for (const chunk of chunks) { buffer.set(chunk, offset); offset += chunk.length }
   return new TextDecoder().decode(buffer)
 }

--- a/src/app/api/osint/identity/route.ts
+++ b/src/app/api/osint/identity/route.ts
@@ -1,0 +1,98 @@
+import { NextResponse } from "next/server"
+import { buildRateLimitHeaders, checkRateLimit, getCached, getClientId, setCached } from "@/lib/osint-cache"
+import { captureAPIError } from "@/lib/sentry-utils"
+import type { IdentityData } from "@/lib/osint-types"
+
+const RESPONSE_CACHE_TTL = 10 * 60 * 1000
+const RATE_LIMIT = 30
+const RATE_WINDOW_MS = 60 * 1000
+
+function parseSecurityTxt(text: string): IdentityData["securityTxt"] {
+  const field = (key: string) => {
+    const match = text.match(new RegExp(`^${key}:\\s*(.+)$`, "mi"))
+    return match?.[1]?.trim() ?? null
+  }
+
+  const contact = field("Contact")
+  const policy = field("Policy")
+  const hiring = field("Hiring")
+
+  return {
+    found: true,
+    contact,
+    expires: field("Expires"),
+    policy,
+    encryption: field("Encryption"),
+    acknowledgments: field("Acknowledgments"),
+    hiring,
+    bugBounty: Boolean(policy || hiring),
+  }
+}
+
+async function fetchSecurityTxt(domain: string): Promise<IdentityData["securityTxt"]> {
+  const paths = [
+    `https://${domain}/.well-known/security.txt`,
+    `https://${domain}/security.txt`,
+  ]
+
+  for (const url of paths) {
+    try {
+      const controller = new AbortController()
+      setTimeout(() => controller.abort(), 6000)
+      const res = await fetch(url, {
+        redirect: "follow",
+        signal: controller.signal,
+        headers: { "User-Agent": "dipak.tech-osint/1.0" },
+      })
+      if (res.ok) {
+        const text = await res.text()
+        if (text.includes("Contact:")) return parseSecurityTxt(text)
+      }
+    } catch {
+      continue
+    }
+  }
+
+  return {
+    found: false,
+    contact: null,
+    expires: null,
+    policy: null,
+    encryption: null,
+    acknowledgments: null,
+    hiring: null,
+    bugBounty: false,
+  }
+}
+
+export async function GET(request: Request) {
+  try {
+    const { searchParams } = new URL(request.url)
+    const target = searchParams.get("target")
+    if (!target) return NextResponse.json({ error: "Target parameter is required" }, { status: 400 })
+
+    const normalized = target.trim().toLowerCase()
+    const cacheKey = `identity:${normalized}`
+    const cached = getCached<IdentityData>(cacheKey)
+    if (cached) return NextResponse.json(cached, { headers: { "X-Cache": "HIT" } })
+
+    const clientId = getClientId(request.headers)
+    const rateInfo = checkRateLimit(clientId, RATE_LIMIT, RATE_WINDOW_MS)
+    if (!rateInfo.allowed) {
+      return NextResponse.json({ error: "Rate limit exceeded" }, {
+        status: 429,
+        headers: { ...buildRateLimitHeaders(RATE_LIMIT, rateInfo), "Retry-After": String(Math.ceil(rateInfo.resetAt / 1000)) },
+      })
+    }
+
+    const securityTxt = await fetchSecurityTxt(normalized)
+    const payload: IdentityData = { securityTxt }
+
+    setCached(cacheKey, payload, RESPONSE_CACHE_TTL)
+    return NextResponse.json(payload, {
+      headers: { "X-Cache": "MISS", ...buildRateLimitHeaders(RATE_LIMIT, rateInfo) },
+    })
+  } catch (error) {
+    return captureAPIError(error, request, 500, { operation: "identity_check" })
+  }
+}

--- a/src/app/api/osint/identity/route.ts
+++ b/src/app/api/osint/identity/route.ts
@@ -46,7 +46,7 @@ async function fetchSecurityTxt(domain: string): Promise<IdentityData["securityT
       })
       if (res.ok) {
         const text = await res.text()
-        if (text.includes("Contact:")) return parseSecurityTxt(text)
+        if (/^contact:/im.test(text)) return parseSecurityTxt(text)
       }
     } catch {
       continue

--- a/src/app/api/osint/image-proxy/route.ts
+++ b/src/app/api/osint/image-proxy/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server"
+import { verifyImageUrl } from "@/lib/osint-image-sign"
 
 const ALLOWED_CONTENT_TYPES = ["image/png", "image/jpeg", "image/gif", "image/webp", "image/svg+xml", "image/x-icon", "image/avif"]
 const MAX_SIZE_BYTES = 2 * 1024 * 1024 // 2 MB
@@ -6,8 +7,12 @@ const MAX_SIZE_BYTES = 2 * 1024 * 1024 // 2 MB
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url)
   const url = searchParams.get("url")
+  const token = searchParams.get("token")
 
-  if (!url) return NextResponse.json({ error: "url parameter is required" }, { status: 400 })
+  if (!url || !token) return NextResponse.json({ error: "url and token parameters are required" }, { status: 400 })
+
+  const valid = await verifyImageUrl(url, token)
+  if (!valid) return NextResponse.json({ error: "Invalid token" }, { status: 403 })
 
   let parsed: URL
   try {

--- a/src/app/api/osint/image-proxy/route.ts
+++ b/src/app/api/osint/image-proxy/route.ts
@@ -1,0 +1,56 @@
+import { NextResponse } from "next/server"
+
+const ALLOWED_CONTENT_TYPES = ["image/png", "image/jpeg", "image/gif", "image/webp", "image/svg+xml", "image/x-icon", "image/avif"]
+const MAX_SIZE_BYTES = 2 * 1024 * 1024 // 2 MB
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url)
+  const url = searchParams.get("url")
+
+  if (!url) return NextResponse.json({ error: "url parameter is required" }, { status: 400 })
+
+  let parsed: URL
+  try {
+    parsed = new URL(url)
+  } catch {
+    return NextResponse.json({ error: "Invalid URL" }, { status: 400 })
+  }
+
+  if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+    return NextResponse.json({ error: "Only http/https URLs allowed" }, { status: 400 })
+  }
+
+  try {
+    const controller = new AbortController()
+    setTimeout(() => controller.abort(), 8000)
+
+    const upstream = await fetch(parsed.toString(), {
+      signal: controller.signal,
+      headers: { "User-Agent": "dipak.tech-osint/1.0" },
+    })
+
+    if (!upstream.ok) {
+      return NextResponse.json({ error: "Upstream fetch failed" }, { status: 502 })
+    }
+
+    const contentType = upstream.headers.get("content-type")?.split(";")[0].trim() ?? ""
+    if (!ALLOWED_CONTENT_TYPES.includes(contentType)) {
+      return NextResponse.json({ error: "Not an image" }, { status: 415 })
+    }
+
+    const buffer = await upstream.arrayBuffer()
+    if (buffer.byteLength > MAX_SIZE_BYTES) {
+      return NextResponse.json({ error: "Image too large" }, { status: 413 })
+    }
+
+    return new Response(buffer, {
+      headers: {
+        "Content-Type": contentType,
+        "Cache-Control": "public, max-age=3600",
+        "X-Content-Type-Options": "nosniff",
+      },
+    })
+  } catch {
+    return NextResponse.json({ error: "Failed to fetch image" }, { status: 502 })
+  }
+}

--- a/src/app/api/osint/security/route.ts
+++ b/src/app/api/osint/security/route.ts
@@ -76,7 +76,7 @@ export async function GET(request: Request) {
     if (!isIP) {
       const dsRecords = await dohQuery(normalized, "DS")
       if (dsRecords.length > 0) {
-        const algoNum = parseInt(dsRecords[0].split(" ")[2] ?? "0", 10)
+        const algoNum = parseInt(dsRecords[0].split(" ")[1] ?? "0", 10)
         const algorithms: Record<number, string> = {
           5: "RSA/SHA-1", 7: "RSASHA1-NSEC3-SHA1", 8: "RSA/SHA-256",
           10: "RSA/SHA-512", 13: "ECDSA P-256/SHA-256", 14: "ECDSA P-384/SHA-384",

--- a/src/app/api/osint/security/route.ts
+++ b/src/app/api/osint/security/route.ts
@@ -45,6 +45,13 @@ async function dohQuery(name: string, type = "A"): Promise<string[]> {
   }
 }
 
+function isValidDKIMRecord(raw: string): boolean {
+  const r = raw.startsWith('"') && raw.endsWith('"') ? raw.slice(1, -1) : raw
+  if (!r.includes("v=DKIM1")) return false
+  const pMatch = r.match(/(?:^|;)\s*p=([^;]*)/)
+  return pMatch !== null && pMatch[1].trim().length > 0
+}
+
 async function checkDNSBL(query: string): Promise<boolean> {
   const answers = await dohQuery(query, "A")
   return answers.length > 0
@@ -76,27 +83,34 @@ export async function GET(request: Request) {
     if (!isIP) {
       const dsRecords = await dohQuery(normalized, "DS")
       if (dsRecords.length > 0) {
-        const algoNum = parseInt(dsRecords[0].split(" ")[1] ?? "0", 10)
+        const tokens = dsRecords[0].trim().split(/\s+/)
+        const algoNum = parseInt(tokens[1] ?? "0", 10)
         const algorithms: Record<number, string> = {
           5: "RSA/SHA-1", 7: "RSASHA1-NSEC3-SHA1", 8: "RSA/SHA-256",
           10: "RSA/SHA-512", 13: "ECDSA P-256/SHA-256", 14: "ECDSA P-384/SHA-384",
           15: "Ed25519", 16: "Ed448",
         }
-        dnssec = { enabled: true, algorithm: algorithms[algoNum] ?? `Algorithm ${algoNum}` }
+        dnssec = { enabled: true, algorithm: algorithms[algoNum] ?? (isNaN(algoNum) ? null : `Algorithm ${algoNum}`) }
       }
     }
 
     const dkimSelectors: string[] = []
+    let dkimWildcard = false
     if (!isIP) {
-      const dkimChecks = await Promise.allSettled(
-        COMMON_DKIM_SELECTORS.map(async (sel) => {
-          const records = await dohQuery(`${sel}._domainkey.${normalized}`, "TXT")
-          return records.some((r) => r.includes("v=DKIM1")) ? sel : null
+      const wildcardCheck = await dohQuery(`_wildcard-probe-osint._domainkey.${normalized}`, "TXT")
+      dkimWildcard = wildcardCheck.some((r) => isValidDKIMRecord(r))
+
+      if (!dkimWildcard) {
+        const dkimChecks = await Promise.allSettled(
+          COMMON_DKIM_SELECTORS.map(async (sel) => {
+            const records = await dohQuery(`${sel}._domainkey.${normalized}`, "TXT")
+            return records.some((r) => isValidDKIMRecord(r)) ? sel : null
+          })
+        )
+        dkimChecks.forEach((r) => {
+          if (r.status === "fulfilled" && r.value) dkimSelectors.push(r.value)
         })
-      )
-      dkimChecks.forEach((r) => {
-        if (r.status === "fulfilled" && r.value) dkimSelectors.push(r.value)
-      })
+      }
     }
 
     const listResults = isIP
@@ -116,7 +130,7 @@ export async function GET(request: Request) {
 
     const payload: SecurityData = {
       dnssec,
-      dkim: { selectors: dkimSelectors },
+      dkim: { selectors: dkimSelectors, wildcard: dkimWildcard },
       blocklist: {
         total: blocklistResults.length,
         clean: blocklistResults.filter((r) => !r.listed).length,

--- a/src/app/api/osint/security/route.ts
+++ b/src/app/api/osint/security/route.ts
@@ -1,0 +1,134 @@
+import { NextResponse } from "next/server"
+import { buildRateLimitHeaders, checkRateLimit, getCached, getClientId, setCached } from "@/lib/osint-cache"
+import { captureAPIError } from "@/lib/sentry-utils"
+import type { SecurityData } from "@/lib/osint-types"
+
+const RESPONSE_CACHE_TTL = 10 * 60 * 1000
+const RATE_LIMIT = 30
+const RATE_WINDOW_MS = 60 * 1000
+
+const COMMON_DKIM_SELECTORS = [
+  "google", "mail", "default", "k1", "s1", "s2",
+  "selector1", "selector2", "smtp", "dkim",
+]
+
+const DOMAIN_BLOCKLISTS = [
+  { name: "Spamhaus DBL", zone: "dbl.spamhaus.org" },
+  { name: "SURBL", zone: "multi.surbl.org" },
+  { name: "abuse.ch DBL", zone: "dbl.abuse.ch" },
+]
+
+const IP_BLOCKLISTS = [
+  { name: "Spamhaus ZEN", zone: "zen.spamhaus.org" },
+  { name: "SpamCop", zone: "bl.spamcop.net" },
+  { name: "SORBS SPAM", zone: "spam.dnsbl.sorbs.net" },
+  { name: "Barracuda BRBL", zone: "b.barracudacentral.org" },
+]
+
+function isIPv4(s: string) {
+  return /^(\d{1,3}\.){3}\d{1,3}$/.test(s)
+}
+
+function reverseIP(ip: string) {
+  return ip.split(".").reverse().join(".")
+}
+
+async function dohQuery(name: string, type = "A"): Promise<string[]> {
+  try {
+    const url = `https://cloudflare-dns.com/dns-query?name=${encodeURIComponent(name)}&type=${type}`
+    const res = await fetch(url, { headers: { Accept: "application/dns-json" } })
+    if (!res.ok) return []
+    const data = await res.json()
+    return (data.Answer ?? []).map((r: { data: string }) => r.data)
+  } catch {
+    return []
+  }
+}
+
+async function checkDNSBL(query: string): Promise<boolean> {
+  const answers = await dohQuery(query, "A")
+  return answers.length > 0
+}
+
+export async function GET(request: Request) {
+  try {
+    const { searchParams } = new URL(request.url)
+    const target = searchParams.get("target")
+    if (!target) return NextResponse.json({ error: "Target parameter is required" }, { status: 400 })
+
+    const normalized = target.trim().toLowerCase()
+    const cacheKey = `security:${normalized}`
+    const cached = getCached<SecurityData>(cacheKey)
+    if (cached) return NextResponse.json(cached, { headers: { "X-Cache": "HIT" } })
+
+    const clientId = getClientId(request.headers)
+    const rateInfo = checkRateLimit(clientId, RATE_LIMIT, RATE_WINDOW_MS)
+    if (!rateInfo.allowed) {
+      return NextResponse.json({ error: "Rate limit exceeded" }, {
+        status: 429,
+        headers: { ...buildRateLimitHeaders(RATE_LIMIT, rateInfo), "Retry-After": String(Math.ceil(rateInfo.resetAt / 1000)) },
+      })
+    }
+
+    const isIP = isIPv4(normalized)
+
+    let dnssec: SecurityData["dnssec"] = { enabled: false, algorithm: null }
+    if (!isIP) {
+      const dsRecords = await dohQuery(normalized, "DS")
+      if (dsRecords.length > 0) {
+        const algoNum = parseInt(dsRecords[0].split(" ")[2] ?? "0", 10)
+        const algorithms: Record<number, string> = {
+          5: "RSA/SHA-1", 7: "RSASHA1-NSEC3-SHA1", 8: "RSA/SHA-256",
+          10: "RSA/SHA-512", 13: "ECDSA P-256/SHA-256", 14: "ECDSA P-384/SHA-384",
+          15: "Ed25519", 16: "Ed448",
+        }
+        dnssec = { enabled: true, algorithm: algorithms[algoNum] ?? `Algorithm ${algoNum}` }
+      }
+    }
+
+    const dkimSelectors: string[] = []
+    if (!isIP) {
+      const dkimChecks = await Promise.allSettled(
+        COMMON_DKIM_SELECTORS.map(async (sel) => {
+          const records = await dohQuery(`${sel}._domainkey.${normalized}`, "TXT")
+          return records.some((r) => r.includes("v=DKIM1")) ? sel : null
+        })
+      )
+      dkimChecks.forEach((r) => {
+        if (r.status === "fulfilled" && r.value) dkimSelectors.push(r.value)
+      })
+    }
+
+    const listResults = isIP
+      ? IP_BLOCKLISTS.map((l) => ({ name: l.name, zone: `${reverseIP(normalized)}.${l.zone}` }))
+      : DOMAIN_BLOCKLISTS.map((l) => ({ name: l.name, zone: `${normalized}.${l.zone}` }))
+
+    const blocklistChecks = await Promise.allSettled(
+      listResults.map(async ({ name, zone }) => ({
+        name,
+        listed: await checkDNSBL(zone),
+      }))
+    )
+
+    const blocklistResults = blocklistChecks
+      .filter((r): r is PromiseFulfilledResult<{ name: string; listed: boolean }> => r.status === "fulfilled")
+      .map((r) => r.value)
+
+    const payload: SecurityData = {
+      dnssec,
+      dkim: { selectors: dkimSelectors },
+      blocklist: {
+        total: blocklistResults.length,
+        clean: blocklistResults.filter((r) => !r.listed).length,
+        results: blocklistResults,
+      },
+    }
+
+    setCached(cacheKey, payload, RESPONSE_CACHE_TTL)
+    return NextResponse.json(payload, {
+      headers: { "X-Cache": "MISS", ...buildRateLimitHeaders(RATE_LIMIT, rateInfo) },
+    })
+  } catch (error) {
+    return captureAPIError(error, request, 500, { operation: "security_check" })
+  }
+}

--- a/src/app/api/osint/threat/route.ts
+++ b/src/app/api/osint/threat/route.ts
@@ -1,0 +1,170 @@
+import { NextResponse } from "next/server"
+import { buildRateLimitHeaders, checkRateLimit, getCached, getClientId, setCached } from "@/lib/osint-cache"
+import { captureAPIError } from "@/lib/sentry-utils"
+import type { ThreatData, ShodanHostInfo } from "@/lib/osint-types"
+
+const RESPONSE_CACHE_TTL = 30 * 60 * 1000
+const RATE_LIMIT = 20
+const RATE_WINDOW_MS = 60 * 1000
+
+function isIPv4(s: string) { return /^(\d{1,3}\.){3}\d{1,3}$/.test(s) }
+
+async function resolveIPs(domain: string): Promise<string[]> {
+  try {
+    const url = `https://cloudflare-dns.com/dns-query?name=${encodeURIComponent(domain)}&type=A`
+    const res = await fetch(url, { headers: { Accept: "application/dns-json" } })
+    if (!res.ok) return []
+    const data = await res.json()
+    return (data.Answer ?? []).map((r: { data: string }) => r.data).filter(isIPv4)
+  } catch { return [] }
+}
+
+async function fetchShodan(ip: string): Promise<ShodanHostInfo | null> {
+  try {
+    const controller = new AbortController()
+    setTimeout(() => controller.abort(), 5000)
+    const res = await fetch(`https://internetdb.shodan.io/${ip}`, {
+      signal: controller.signal,
+      headers: { "User-Agent": "dipak.tech-osint/1.0" },
+    })
+    if (!res.ok) return null
+    const data = await res.json()
+    return {
+      ip,
+      ports: data.ports ?? [],
+      vulns: data.vulns ?? [],
+      tags: data.tags ?? [],
+    }
+  } catch { return null }
+}
+
+async function fetchWayback(domain: string): Promise<ThreatData["wayback"]> {
+  try {
+    const controller = new AbortController()
+    setTimeout(() => controller.abort(), 8000)
+
+    const [availRes, firstRes, countRes] = await Promise.allSettled([
+      fetch(`https://archive.org/wayback/available?url=${encodeURIComponent(domain)}`, { signal: controller.signal }),
+      fetch(`https://web.archive.org/cdx/search/cdx?url=${encodeURIComponent(domain)}&output=json&fl=timestamp&limit=1&from=19960101`),
+      fetch(`https://web.archive.org/cdx/search/cdx?url=${encodeURIComponent(domain)}&output=json&fl=timestamp&collapse=timestamp:8&showNumPages=true`),
+    ])
+
+    let latestUrl: string | null = null
+    let lastArchived: string | null = null
+    if (availRes.status === "fulfilled" && availRes.value.ok) {
+      const avail = await availRes.value.json()
+      latestUrl = avail?.archived_snapshots?.closest?.url ?? null
+      const ts = avail?.archived_snapshots?.closest?.timestamp
+      if (ts) lastArchived = `${ts.slice(0, 4)}-${ts.slice(4, 6)}-${ts.slice(6, 8)}`
+    }
+
+    let firstSeen: string | null = null
+    if (firstRes.status === "fulfilled" && firstRes.value.ok) {
+      const rows = await firstRes.value.json()
+      const ts = rows?.[1]?.[0]
+      if (ts) firstSeen = ts.slice(0, 4)
+    }
+
+    let approximateCount: number | null = null
+    if (countRes.status === "fulfilled" && countRes.value.ok) {
+      const text = await countRes.value.text()
+      const num = parseInt(text.trim(), 10)
+      if (!isNaN(num)) approximateCount = num
+    }
+
+    return {
+      available: latestUrl !== null,
+      firstSeen,
+      lastArchived,
+      latestUrl,
+      approximateCount,
+    }
+  } catch {
+    return { available: false, firstSeen: null, lastArchived: null, latestUrl: null, approximateCount: null }
+  }
+}
+
+async function fetchCrawlRules(domain: string): Promise<ThreatData["crawl"]> {
+  const robots = { found: false, disallowCount: 0, userAgentCount: 0, sitemapUrls: [] as string[] }
+  const sitemap = { found: false, urlCount: 0, lastModified: null as string | null }
+
+  try {
+    const controller = new AbortController()
+    setTimeout(() => controller.abort(), 5000)
+    const res = await fetch(`https://${domain}/robots.txt`, { signal: controller.signal, redirect: "follow" })
+    if (res.ok) {
+      const text = await res.text()
+      const disallows = (text.match(/^Disallow:/gim) ?? []).length
+      const userAgents = new Set((text.match(/^User-agent:\s*(.+)/gim) ?? []).map((l) => l.replace(/^User-agent:\s*/i, "").trim()))
+      const sitemapUrls = (text.match(/^Sitemap:\s*(.+)/gim) ?? []).map((l) => l.replace(/^Sitemap:\s*/i, "").trim())
+      Object.assign(robots, { found: true, disallowCount: disallows, userAgentCount: userAgents.size, sitemapUrls })
+    }
+  } catch { /* ignore */ }
+
+  const sitemapUrlsToTry = robots.sitemapUrls.length > 0
+    ? robots.sitemapUrls.slice(0, 2)
+    : [`https://${domain}/sitemap.xml`, `https://${domain}/sitemap_index.xml`]
+
+  for (const sitemapUrl of sitemapUrlsToTry) {
+    try {
+      const controller = new AbortController()
+      setTimeout(() => controller.abort(), 5000)
+      const res = await fetch(sitemapUrl, { signal: controller.signal, redirect: "follow" })
+      if (res.ok) {
+        const text = await res.text()
+        const urlCount = (text.match(/<loc>/g) ?? []).length
+        const lastModMatch = text.match(/<lastmod>([^<]+)<\/lastmod>/)
+        sitemap.found = true
+        sitemap.urlCount = urlCount
+        sitemap.lastModified = lastModMatch?.[1]?.slice(0, 10) ?? null
+        break
+      }
+    } catch { continue }
+  }
+
+  return { robots, sitemap }
+}
+
+export async function GET(request: Request) {
+  try {
+    const { searchParams } = new URL(request.url)
+    const target = searchParams.get("target")
+    if (!target) return NextResponse.json({ error: "Target parameter is required" }, { status: 400 })
+
+    const normalized = target.trim().toLowerCase()
+    const cacheKey = `threat:${normalized}`
+    const cached = getCached<ThreatData>(cacheKey)
+    if (cached) return NextResponse.json(cached, { headers: { "X-Cache": "HIT" } })
+
+    const clientId = getClientId(request.headers)
+    const rateInfo = checkRateLimit(clientId, RATE_LIMIT, RATE_WINDOW_MS)
+    if (!rateInfo.allowed) {
+      return NextResponse.json({ error: "Rate limit exceeded" }, {
+        status: 429,
+        headers: { ...buildRateLimitHeaders(RATE_LIMIT, rateInfo), "Retry-After": String(Math.ceil(rateInfo.resetAt / 1000)) },
+      })
+    }
+
+    const isIP = isIPv4(normalized)
+    const ipsToCheck = isIP ? [normalized] : (await resolveIPs(normalized)).slice(0, 3)
+
+    const [shodanResults, wayback, crawl] = await Promise.all([
+      Promise.all(ipsToCheck.map(fetchShodan)),
+      isIP ? Promise.resolve({ available: false, firstSeen: null, lastArchived: null, latestUrl: null, approximateCount: null }) : fetchWayback(normalized),
+      isIP ? Promise.resolve({ robots: { found: false, disallowCount: 0, userAgentCount: 0, sitemapUrls: [] }, sitemap: { found: false, urlCount: 0, lastModified: null } }) : fetchCrawlRules(normalized),
+    ])
+
+    const payload: ThreatData = {
+      shodan: shodanResults.filter((r): r is ShodanHostInfo => r !== null),
+      wayback,
+      crawl,
+    }
+
+    setCached(cacheKey, payload, RESPONSE_CACHE_TTL)
+    return NextResponse.json(payload, {
+      headers: { "X-Cache": "MISS", ...buildRateLimitHeaders(RATE_LIMIT, rateInfo) },
+    })
+  } catch (error) {
+    return captureAPIError(error, request, 500, { operation: "threat_check" })
+  }
+}

--- a/src/app/api/osint/threat/route.ts
+++ b/src/app/api/osint/threat/route.ts
@@ -45,8 +45,8 @@ async function fetchWayback(domain: string): Promise<ThreatData["wayback"]> {
 
     const [availRes, firstRes, countRes] = await Promise.allSettled([
       fetch(`https://archive.org/wayback/available?url=${encodeURIComponent(domain)}`, { signal: controller.signal }),
-      fetch(`https://web.archive.org/cdx/search/cdx?url=${encodeURIComponent(domain)}&output=json&fl=timestamp&limit=1&from=19960101`),
-      fetch(`https://web.archive.org/cdx/search/cdx?url=${encodeURIComponent(domain)}&output=json&fl=timestamp&collapse=timestamp:8&showNumPages=true`),
+      fetch(`https://web.archive.org/cdx/search/cdx?url=${encodeURIComponent(domain)}&output=json&fl=timestamp&limit=1&from=19960101`, { signal: controller.signal }),
+      fetch(`https://web.archive.org/cdx/search/cdx?url=${encodeURIComponent(domain)}&output=json&fl=timestamp&collapse=timestamp:8&showNumPages=true`, { signal: controller.signal }),
     ])
 
     let latestUrl: string | null = null

--- a/src/components/osint-results.tsx
+++ b/src/components/osint-results.tsx
@@ -12,7 +12,7 @@ import { SecurityPosture } from "@/components/osint/security-posture"
 import { SiteIdentity } from "@/components/osint/site-identity"
 import { ThreatHistory } from "@/components/osint/threat-history"
 import { RedirectChain } from "@/components/osint/redirect-chain"
-import type { SecurityData, IdentityData, ThreatData } from "@/lib/osint-types"
+import type { SecurityData, IdentityData, ThreatData, RedirectHop } from "@/lib/osint-types"
 
 // Known security headers to filter out from regular headers
 const SECURITY_HEADER_KEYS = new Set([
@@ -642,71 +642,72 @@ export function OsintResults({
           </Card>
         )}
 
-        {/* Security Posture */}
-        {(securityData || pending.security || dnsData || pending.dns) && (
-          <Card className="md:col-span-2 xl:col-span-3">
-            <CardHeader className="pb-3">
-              <CardTitle className="flex items-center gap-2 text-sm font-semibold">
-                <ShieldCheck className="h-4 w-4 text-primary" />
-                Security Posture
-              </CardTitle>
-              <CardDescription>WAF, DNSSEC, email authentication, and blocklist status</CardDescription>
-            </CardHeader>
-            <CardContent>
-              <SecurityPosture
-                securityData={securityData ?? null}
-                emailSecurity={dnsData?.emailSecurity ?? null}
-                waf={httpData?.waf ?? null}
-                pending={Boolean(pending.security)}
-                error={errors.security}
-              />
-            </CardContent>
-          </Card>
-        )}
-
-        {/* Site Identity */}
-        {(identityData || httpData?.techStack || pending.identity || pending.http) && (
-          <Card className="md:col-span-2 xl:col-span-3">
-            <CardHeader className="pb-3">
-              <CardTitle className="flex items-center gap-2 text-sm font-semibold">
-                <Globe className="h-4 w-4 text-primary" />
-                Site Identity
-              </CardTitle>
-              <CardDescription>Technology stack, social tags, cookies, and security disclosure</CardDescription>
-            </CardHeader>
-            <CardContent>
-              <SiteIdentity
-                techStack={httpData?.techStack ?? null}
-                socialTags={httpData?.socialTags ?? null}
-                cookies={httpData?.cookies ?? null}
-                identityData={identityData ?? null}
-                pending={Boolean(pending.identity)}
-                error={errors.identity}
-              />
-            </CardContent>
-          </Card>
-        )}
-
-        {/* Threat & History */}
-        {(threatData || pending.threat) && (
-          <Card className="md:col-span-2 xl:col-span-3">
-            <CardHeader className="pb-3">
-              <CardTitle className="flex items-center gap-2 text-sm font-semibold">
-                <Activity className="h-4 w-4 text-primary" />
-                Threat & History
-              </CardTitle>
-              <CardDescription>Open ports, CVEs, archive history, and crawl rules</CardDescription>
-            </CardHeader>
-            <CardContent>
-              <ThreatHistory
-                threatData={threatData ?? null}
-                pending={Boolean(pending.threat)}
-                error={errors.threat}
-              />
-            </CardContent>
-          </Card>
-        )}
       </section>
+
+      {/* Security Posture */}
+      {(securityData || pending.security || errors.security) && (
+        <Card>
+          <CardHeader className="pb-3">
+            <CardTitle className="flex items-center gap-2 text-sm font-semibold">
+              <ShieldCheck className="h-4 w-4 text-primary" />
+              Security Posture
+            </CardTitle>
+            <CardDescription>WAF, DNSSEC, email authentication, and blocklist status</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <SecurityPosture
+              securityData={securityData ?? null}
+              emailSecurity={dnsData?.emailSecurity ?? null}
+              waf={httpData?.waf ?? null}
+              pending={Boolean(pending.security)}
+              error={errors.security}
+            />
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Site Identity */}
+      {(identityData || httpData?.techStack || pending.identity || pending.http) && (
+        <Card>
+          <CardHeader className="pb-3">
+            <CardTitle className="flex items-center gap-2 text-sm font-semibold">
+              <Globe className="h-4 w-4 text-primary" />
+              Site Identity
+            </CardTitle>
+            <CardDescription>Technology stack, social tags, cookies, and security disclosure</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <SiteIdentity
+              techStack={httpData?.techStack ?? null}
+              socialTags={httpData?.socialTags ?? null}
+              cookies={httpData?.cookies ?? null}
+              identityData={identityData ?? null}
+              pending={Boolean(pending.identity)}
+              error={errors.identity}
+            />
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Threat & History */}
+      {(threatData || pending.threat) && (
+        <Card>
+          <CardHeader className="pb-3">
+            <CardTitle className="flex items-center gap-2 text-sm font-semibold">
+              <Activity className="h-4 w-4 text-primary" />
+              Threat & History
+            </CardTitle>
+            <CardDescription>Open ports, CVEs, archive history, and crawl rules</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <ThreatHistory
+              threatData={threatData ?? null}
+              pending={Boolean(pending.threat)}
+              error={errors.threat}
+            />
+          </CardContent>
+        </Card>
+      )}
     </div>
   )
 }

--- a/src/components/osint-results.tsx
+++ b/src/components/osint-results.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { Activity, AlertTriangle, Globe, Info, Lock, Network, ShieldCheck } from "lucide-react"
+import { Activity, AlertTriangle, Globe, Info, Network, ShieldCheck } from "lucide-react"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Tabs, TabsContent, TabsList } from "@/components/ui/tabs"
 import { HapticTabsTrigger as TabsTrigger } from "@/components/haptic-wrappers"
@@ -8,6 +8,11 @@ import { HapticTabsTrigger as TabsTrigger } from "@/components/haptic-wrappers"
 import { Badge } from "@/components/ui/badge"
 import { Skeleton } from "@/components/ui/skeleton"
 import { WhoisResults } from "@/components/whois-results"
+import { SecurityPosture } from "@/components/osint/security-posture"
+import { SiteIdentity } from "@/components/osint/site-identity"
+import { ThreatHistory } from "@/components/osint/threat-history"
+import { RedirectChain } from "@/components/osint/redirect-chain"
+import type { SecurityData, IdentityData, ThreatData } from "@/lib/osint-types"
 
 // Known security headers to filter out from regular headers
 const SECURITY_HEADER_KEYS = new Set([
@@ -36,10 +41,16 @@ interface OsintResultsProps {
     http?: string
     certs?: string
     ip?: string
+    security?: string
+    identity?: string
+    threat?: string
   }
   pending: Record<string, boolean>
   certDnsData?: Record<string, any> | null
   certDnsPending?: Record<string, boolean>
+  securityData?: SecurityData | null
+  identityData?: IdentityData | null
+  threatData?: ThreatData | null
 }
 
 export function OsintResults({
@@ -53,6 +64,9 @@ export function OsintResults({
   pending,
   certDnsData,
   certDnsPending,
+  securityData,
+  identityData,
+  threatData,
 }: OsintResultsProps) {
   // Determine which cards have content to show
   const hasHttp = httpData || pending.http
@@ -495,43 +509,53 @@ export function OsintResults({
                     </div>
                   )}
 
-                  {/* Regular Headers (excluding security headers) */}
-                  {(() => {
-                    const regularHeaders = getRegularHeaders(httpData.headers)
-                    return Object.keys(regularHeaders).length > 0 && (
-                      <div className="space-y-2">
-                        <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Headers</p>
+                  <Tabs defaultValue="headers" className="w-full">
+                    <TabsList className="mb-4 flex h-auto flex-wrap gap-1 bg-transparent p-0">
+                      <TabsTrigger value="headers" className="rounded-md border bg-muted/50 px-3 py-1.5 text-xs font-medium data-[state=active]:border-violet-500/50 data-[state=active]:bg-violet-500/10 data-[state=active]:text-violet-600 dark:data-[state=active]:text-violet-400">
+                        Headers
+                      </TabsTrigger>
+                      <TabsTrigger value="security-headers" className="rounded-md border bg-muted/50 px-3 py-1.5 text-xs font-medium data-[state=active]:border-violet-500/50 data-[state=active]:bg-violet-500/10 data-[state=active]:text-violet-600 dark:data-[state=active]:text-violet-400">
+                        Security Headers
+                      </TabsTrigger>
+                      <TabsTrigger value="redirect-chain" className="rounded-md border bg-muted/50 px-3 py-1.5 text-xs font-medium data-[state=active]:border-violet-500/50 data-[state=active]:bg-violet-500/10 data-[state=active]:text-violet-600 dark:data-[state=active]:text-violet-400">
+                        Redirect Chain
+                      </TabsTrigger>
+                    </TabsList>
+                    <TabsContent value="headers" className="mt-0">
+                      {(() => {
+                        const regularHeaders = getRegularHeaders(httpData.headers)
+                        return Object.keys(regularHeaders).length > 0 ? (
+                          <div className="space-y-1">
+                            {Object.entries(regularHeaders).map(([key, value]) => (
+                              <div key={key} className="rounded-md border bg-muted/30 px-2 py-1.5 text-xs">
+                                <span className="text-muted-foreground">{key}:</span>{" "}
+                                <span className="break-all font-mono">{value as string}</span>
+                              </div>
+                            ))}
+                          </div>
+                        ) : (
+                          <p className="py-4 text-center text-sm text-muted-foreground">No headers found</p>
+                        )
+                      })()}
+                    </TabsContent>
+                    <TabsContent value="security-headers" className="mt-0">
+                      {Object.keys(httpData.securityHeaders || {}).length > 0 ? (
                         <div className="space-y-1">
-                          {Object.entries(regularHeaders).map(([key, value]) => (
-                            <div key={key} className="rounded-md border bg-muted/30 px-2 py-1.5 text-xs">
-                              <span className="text-muted-foreground">{key}:</span>{" "}
+                          {Object.entries(httpData.securityHeaders || {}).map(([key, value]) => (
+                            <div key={key} className="rounded-md border border-emerald-500/20 bg-emerald-500/5 px-2 py-1.5 text-xs">
+                              <span className="text-emerald-600 dark:text-emerald-400">{key}:</span>{" "}
                               <span className="break-all font-mono">{value as string}</span>
                             </div>
                           ))}
                         </div>
-                      </div>
-                    )
-                  })()}
-
-                  {/* Security Headers */}
-                  <div className="space-y-2">
-                    <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                      <Lock className="h-3 w-3" />
-                      Security Headers
-                    </div>
-                    {Object.keys(httpData.securityHeaders || {}).length > 0 ? (
-                      <div className="space-y-1">
-                        {Object.entries(httpData.securityHeaders || {}).map(([key, value]) => (
-                          <div key={key} className="rounded-md border border-emerald-500/20 bg-emerald-500/5 px-2 py-1.5 text-xs">
-                            <span className="text-emerald-600 dark:text-emerald-400">{key}:</span>{" "}
-                            <span className="break-all font-mono">{value as string}</span>
-                          </div>
-                        ))}
-                      </div>
-                    ) : (
-                      <p className="text-xs text-amber-600 dark:text-amber-400">No security headers detected</p>
-                    )}
-                  </div>
+                      ) : (
+                        <p className="text-xs text-amber-600 dark:text-amber-400">No security headers detected</p>
+                      )}
+                    </TabsContent>
+                    <TabsContent value="redirect-chain" className="mt-4">
+                      <RedirectChain chain={httpData.redirectChain ?? []} />
+                    </TabsContent>
+                  </Tabs>
                 </div>
               ) : pending.http ? (
                 <div className="space-y-3">
@@ -614,6 +638,71 @@ export function OsintResults({
                   {errors.certs || "Certificate data not available"}
                 </p>
               )}
+            </CardContent>
+          </Card>
+        )}
+
+        {/* Security Posture */}
+        {(securityData || pending.security || dnsData || pending.dns) && (
+          <Card className="md:col-span-2 xl:col-span-3">
+            <CardHeader className="pb-3">
+              <CardTitle className="flex items-center gap-2 text-sm font-semibold">
+                <ShieldCheck className="h-4 w-4 text-primary" />
+                Security Posture
+              </CardTitle>
+              <CardDescription>WAF, DNSSEC, email authentication, and blocklist status</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <SecurityPosture
+                securityData={securityData ?? null}
+                emailSecurity={dnsData?.emailSecurity ?? null}
+                waf={httpData?.waf ?? null}
+                pending={Boolean(pending.security)}
+                error={errors.security}
+              />
+            </CardContent>
+          </Card>
+        )}
+
+        {/* Site Identity */}
+        {(identityData || httpData?.techStack || pending.identity || pending.http) && (
+          <Card className="md:col-span-2 xl:col-span-3">
+            <CardHeader className="pb-3">
+              <CardTitle className="flex items-center gap-2 text-sm font-semibold">
+                <Globe className="h-4 w-4 text-primary" />
+                Site Identity
+              </CardTitle>
+              <CardDescription>Technology stack, social tags, cookies, and security disclosure</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <SiteIdentity
+                techStack={httpData?.techStack ?? null}
+                socialTags={httpData?.socialTags ?? null}
+                cookies={httpData?.cookies ?? null}
+                identityData={identityData ?? null}
+                pending={Boolean(pending.identity)}
+                error={errors.identity}
+              />
+            </CardContent>
+          </Card>
+        )}
+
+        {/* Threat & History */}
+        {(threatData || pending.threat) && (
+          <Card className="md:col-span-2 xl:col-span-3">
+            <CardHeader className="pb-3">
+              <CardTitle className="flex items-center gap-2 text-sm font-semibold">
+                <Activity className="h-4 w-4 text-primary" />
+                Threat & History
+              </CardTitle>
+              <CardDescription>Open ports, CVEs, archive history, and crawl rules</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <ThreatHistory
+                threatData={threatData ?? null}
+                pending={Boolean(pending.threat)}
+                error={errors.threat}
+              />
             </CardContent>
           </Card>
         )}

--- a/src/components/osint/redirect-chain.tsx
+++ b/src/components/osint/redirect-chain.tsx
@@ -1,0 +1,60 @@
+"use client"
+
+import { Badge } from "@/components/ui/badge"
+import { ArrowDown } from "lucide-react"
+import type { RedirectHop } from "@/lib/osint-types"
+
+interface RedirectChainProps {
+  chain: RedirectHop[]
+}
+
+function statusColor(status: number) {
+  if (status >= 200 && status < 300) return "bg-emerald-950 text-emerald-400 border-emerald-800"
+  if (status >= 300 && status < 400) return "bg-amber-950 text-amber-400 border-amber-900"
+  return "bg-red-950 text-red-400 border-red-900"
+}
+
+export function RedirectChain({ chain }: RedirectChainProps) {
+  if (chain.length === 0) return <div className="text-sm text-muted-foreground">No redirect data</div>
+
+  const totalMs = chain.reduce((sum, hop) => sum + hop.latencyMs, 0)
+  const finalHop = chain[chain.length - 1]
+  const isHTTPS = finalHop?.url?.startsWith("https://")
+  const hasOpenRedirect = chain.some((hop, i) => {
+    if (i === 0) return false
+    try {
+      return new URL(hop.url).hostname !== new URL(chain[0].url).hostname
+    } catch { return false }
+  })
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-wrap gap-2">
+        <Badge className={`text-xs ${chain.length === 1 ? "bg-emerald-950 text-emerald-400 border-emerald-800" : "bg-amber-950 text-amber-400 border-amber-900"}`}>
+          {chain.length} {chain.length === 1 ? "hop" : "hops"}
+        </Badge>
+        <Badge variant="outline" className="text-xs">{totalMs}ms total</Badge>
+        {isHTTPS && <Badge className="bg-emerald-950 text-emerald-400 border-emerald-800 text-xs">HTTPS enforced</Badge>}
+        {hasOpenRedirect && (
+          <Badge className="bg-red-950 text-red-400 border-red-900 text-xs">Open redirect detected</Badge>
+        )}
+      </div>
+      <div className="space-y-1">
+        {chain.map((hop, i) => (
+          <div key={i}>
+            <div className="flex items-center gap-3 rounded-lg border border-border/40 bg-muted/20 px-3 py-2">
+              <Badge className={`shrink-0 font-mono text-xs ${statusColor(hop.status)}`}>{hop.status}</Badge>
+              <span className="min-w-0 flex-1 truncate font-mono text-xs text-muted-foreground">{hop.url}</span>
+              <span className="shrink-0 text-xs text-muted-foreground">{hop.latencyMs}ms</span>
+            </div>
+            {i < chain.length - 1 && (
+              <div className="flex justify-center py-0.5">
+                <ArrowDown className="h-3 w-3 text-border" />
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/components/osint/security-posture.tsx
+++ b/src/components/osint/security-posture.tsx
@@ -2,7 +2,7 @@
 
 import { Badge } from "@/components/ui/badge"
 import { Skeleton } from "@/components/ui/skeleton"
-import { Shield, ShieldCheck, ShieldAlert, ShieldOff, Mail, Server, Lock } from "lucide-react"
+import { Shield, ShieldCheck, ShieldAlert, ShieldOff, Mail, Server, Lock, Key } from "lucide-react"
 import type { SecurityData, EmailSecurityResult, WAFResult } from "@/lib/osint-types"
 
 interface SecurityPostureProps {
@@ -91,12 +91,6 @@ export function SecurityPosture({ securityData, emailSecurity, waf, pending, err
               {securityData.dnssec.algorithm && (
                 <div className="text-xs text-muted-foreground">{securityData.dnssec.algorithm}</div>
               )}
-              {securityData.dkim.selectors.length > 0 && (
-                <div className="mt-2">
-                  <span className="text-xs text-muted-foreground">DKIM: </span>
-                  <span className="text-xs text-foreground">{securityData.dkim.selectors.join(", ")}</span>
-                </div>
-              )}
             </div>
           ) : (
             <Skeleton className="h-8 w-full" />
@@ -104,8 +98,8 @@ export function SecurityPosture({ securityData, emailSecurity, waf, pending, err
         </div>
       </div>
 
-      {/* Email security row */}
-      <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+      {/* Email security row — SPF / DMARC / DKIM / BIMI */}
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
         {/* SPF */}
         <div className="rounded-2xl border border-border/60 bg-card p-4">
           <div className="mb-2 flex items-center gap-2">
@@ -119,7 +113,7 @@ export function SecurityPosture({ securityData, emailSecurity, waf, pending, err
               ) : (
                 <StatusBadge
                   pass={spfPolicy === "fail"}
-                  label={spfPolicy === "fail" ? "Hard Fail" : spfPolicy === "none" ? "Not Set" : "Neutral"}
+                  label={spfPolicy === "fail" ? "Enforced (-all)" : spfPolicy === "none" ? "Not Set" : "Neutral"}
                 />
               )}
               {emailSecurity.spf.record && (
@@ -148,6 +142,28 @@ export function SecurityPosture({ securityData, emailSecurity, waf, pending, err
                   {emailSecurity.dmarc.reporting && <WarnBadge label="rua reporting" />}
                   {emailSecurity.dmarc.pct < 100 && <WarnBadge label={`${emailSecurity.dmarc.pct}% policy`} />}
                 </div>
+              )}
+            </>
+          ) : <Skeleton className="h-6 w-24" />}
+        </div>
+
+        {/* DKIM */}
+        <div className="rounded-2xl border border-border/60 bg-card p-4">
+          <div className="mb-2 flex items-center gap-2">
+            <Key className="h-3.5 w-3.5 text-muted-foreground" />
+            <span className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">DKIM</span>
+          </div>
+          {securityData ? (
+            <>
+              {securityData.dkim.wildcard ? (
+                <WarnBadge label="Wildcard" />
+              ) : securityData.dkim.selectors.length > 0 ? (
+                <StatusBadge pass={true} label="Configured" />
+              ) : (
+                <StatusBadge pass={false} label="Not Found" />
+              )}
+              {!securityData.dkim.wildcard && securityData.dkim.selectors.length > 0 && (
+                <div className="mt-2 text-xs text-muted-foreground">{securityData.dkim.selectors.join(", ")}</div>
               )}
             </>
           ) : <Skeleton className="h-6 w-24" />}

--- a/src/components/osint/security-posture.tsx
+++ b/src/components/osint/security-posture.tsx
@@ -114,10 +114,14 @@ export function SecurityPosture({ securityData, emailSecurity, waf, pending, err
           </div>
           {emailSecurity ? (
             <>
-              <StatusBadge
-                pass={spfPolicy !== "none" && spfPolicy !== "neutral"}
-                label={spfPolicy === "fail" ? "Hard Fail" : spfPolicy === "softfail" ? "Soft Fail" : spfPolicy === "none" ? "Not Set" : "Neutral"}
-              />
+              {spfPolicy === "softfail" ? (
+                <WarnBadge label="Soft Fail" />
+              ) : (
+                <StatusBadge
+                  pass={spfPolicy === "fail"}
+                  label={spfPolicy === "fail" ? "Hard Fail" : spfPolicy === "none" ? "Not Set" : "Neutral"}
+                />
+              )}
               {emailSecurity.spf.record && (
                 <div className="mt-2 truncate rounded bg-muted/40 px-2 py-1 font-mono text-xs text-muted-foreground">
                   {emailSecurity.spf.record}
@@ -179,7 +183,7 @@ export function SecurityPosture({ securityData, emailSecurity, waf, pending, err
           <div className="mb-3 h-1.5 overflow-hidden rounded-full bg-muted">
             <div
               className={`h-full rounded-full transition-all ${securityData.blocklist.clean === securityData.blocklist.total ? "bg-emerald-500" : securityData.blocklist.clean > securityData.blocklist.total / 2 ? "bg-amber-500" : "bg-red-500"}`}
-              style={{ width: `${(securityData.blocklist.clean / securityData.blocklist.total) * 100}%` }}
+              style={{ width: `${securityData.blocklist.total > 0 ? (securityData.blocklist.clean / securityData.blocklist.total) * 100 : 0}%` }}
             />
           </div>
           <div className="grid grid-cols-2 gap-x-4 gap-y-1 sm:grid-cols-3">

--- a/src/components/osint/security-posture.tsx
+++ b/src/components/osint/security-posture.tsx
@@ -1,0 +1,201 @@
+"use client"
+
+import { Badge } from "@/components/ui/badge"
+import { Skeleton } from "@/components/ui/skeleton"
+import { Shield, ShieldCheck, ShieldAlert, ShieldOff, Mail, Server, Lock } from "lucide-react"
+import type { SecurityData, EmailSecurityResult, WAFResult } from "@/lib/osint-types"
+
+interface SecurityPostureProps {
+  securityData: SecurityData | null
+  emailSecurity: EmailSecurityResult | null
+  waf: WAFResult | null
+  pending: boolean
+  error?: string
+}
+
+function StatusBadge({ pass, label }: { pass: boolean | null; label: string }) {
+  if (pass === null) return <Badge variant="outline" className="text-muted-foreground">{label}</Badge>
+  return pass ? (
+    <Badge className="bg-emerald-950 text-emerald-400 border-emerald-800 hover:bg-emerald-950">{label}</Badge>
+  ) : (
+    <Badge className="bg-red-950 text-red-400 border-red-900 hover:bg-red-950">{label}</Badge>
+  )
+}
+
+function WarnBadge({ label }: { label: string }) {
+  return <Badge className="bg-amber-950 text-amber-400 border-amber-900 hover:bg-amber-950">{label}</Badge>
+}
+
+export function SecurityPosture({ securityData, emailSecurity, waf, pending, error }: SecurityPostureProps) {
+  if (error) {
+    return (
+      <div className="rounded-2xl border border-red-900/40 bg-red-950/20 p-4 text-sm text-red-400">
+        Security Posture unavailable: {error}
+      </div>
+    )
+  }
+
+  if (pending || (!securityData && !emailSecurity && !waf)) {
+    return (
+      <div className="space-y-3">
+        <Skeleton className="h-20 w-full rounded-2xl" />
+        <div className="grid grid-cols-3 gap-3">
+          <Skeleton className="h-24 rounded-2xl" />
+          <Skeleton className="h-24 rounded-2xl" />
+          <Skeleton className="h-24 rounded-2xl" />
+        </div>
+      </div>
+    )
+  }
+
+  const spfPolicy = emailSecurity?.spf.policy
+  const dmarcPolicy = emailSecurity?.dmarc.policy
+
+  return (
+    <div className="space-y-3">
+      {/* WAF + DNSSEC row */}
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        {/* WAF */}
+        <div className="rounded-2xl border border-border/60 bg-card p-4">
+          <div className="mb-3 flex items-center gap-2">
+            <Shield className="h-4 w-4 text-muted-foreground" />
+            <span className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">WAF / CDN</span>
+          </div>
+          {waf?.detected ? (
+            <div>
+              <div className="mb-2 text-base font-semibold">{waf.name}</div>
+              <div className="flex flex-wrap gap-1.5">
+                {waf.capabilities.map((cap) => (
+                  <Badge key={cap} className="bg-emerald-950 text-emerald-400 border-emerald-800 text-xs">
+                    {cap}
+                  </Badge>
+                ))}
+              </div>
+            </div>
+          ) : (
+            <div className="text-sm text-muted-foreground">None detected</div>
+          )}
+        </div>
+
+        {/* DNSSEC */}
+        <div className="rounded-2xl border border-border/60 bg-card p-4">
+          <div className="mb-3 flex items-center gap-2">
+            <Lock className="h-4 w-4 text-muted-foreground" />
+            <span className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">DNSSEC</span>
+          </div>
+          {securityData ? (
+            <div>
+              <div className="mb-2 flex items-center gap-2">
+                <StatusBadge pass={securityData.dnssec.enabled} label={securityData.dnssec.enabled ? "Enabled" : "Disabled"} />
+              </div>
+              {securityData.dnssec.algorithm && (
+                <div className="text-xs text-muted-foreground">{securityData.dnssec.algorithm}</div>
+              )}
+              {securityData.dkim.selectors.length > 0 && (
+                <div className="mt-2">
+                  <span className="text-xs text-muted-foreground">DKIM: </span>
+                  <span className="text-xs text-foreground">{securityData.dkim.selectors.join(", ")}</span>
+                </div>
+              )}
+            </div>
+          ) : (
+            <Skeleton className="h-8 w-full" />
+          )}
+        </div>
+      </div>
+
+      {/* Email security row */}
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+        {/* SPF */}
+        <div className="rounded-2xl border border-border/60 bg-card p-4">
+          <div className="mb-2 flex items-center gap-2">
+            <Mail className="h-3.5 w-3.5 text-muted-foreground" />
+            <span className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">SPF</span>
+          </div>
+          {emailSecurity ? (
+            <>
+              <StatusBadge
+                pass={spfPolicy !== "none" && spfPolicy !== "neutral"}
+                label={spfPolicy === "fail" ? "Hard Fail" : spfPolicy === "softfail" ? "Soft Fail" : spfPolicy === "none" ? "Not Set" : "Neutral"}
+              />
+              {emailSecurity.spf.record && (
+                <div className="mt-2 truncate rounded bg-muted/40 px-2 py-1 font-mono text-xs text-muted-foreground">
+                  {emailSecurity.spf.record}
+                </div>
+              )}
+            </>
+          ) : <Skeleton className="h-6 w-24" />}
+        </div>
+
+        {/* DMARC */}
+        <div className="rounded-2xl border border-border/60 bg-card p-4">
+          <div className="mb-2 flex items-center gap-2">
+            <ShieldCheck className="h-3.5 w-3.5 text-muted-foreground" />
+            <span className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">DMARC</span>
+          </div>
+          {emailSecurity ? (
+            <>
+              <StatusBadge
+                pass={dmarcPolicy === "reject" || dmarcPolicy === "quarantine"}
+                label={dmarcPolicy === "reject" ? "Reject" : dmarcPolicy === "quarantine" ? "Quarantine" : "None"}
+              />
+              {emailSecurity.dmarc.record && (
+                <div className="mt-1.5 flex gap-1.5 flex-wrap">
+                  {emailSecurity.dmarc.reporting && <WarnBadge label="rua reporting" />}
+                  {emailSecurity.dmarc.pct < 100 && <WarnBadge label={`${emailSecurity.dmarc.pct}% policy`} />}
+                </div>
+              )}
+            </>
+          ) : <Skeleton className="h-6 w-24" />}
+        </div>
+
+        {/* BIMI */}
+        <div className="rounded-2xl border border-border/60 bg-card p-4">
+          <div className="mb-2 flex items-center gap-2">
+            <Server className="h-3.5 w-3.5 text-muted-foreground" />
+            <span className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">BIMI</span>
+          </div>
+          {emailSecurity ? (
+            <StatusBadge pass={emailSecurity.bimi.present} label={emailSecurity.bimi.present ? "Configured" : "Not Set"} />
+          ) : <Skeleton className="h-6 w-24" />}
+        </div>
+      </div>
+
+      {/* Blocklist */}
+      {securityData && (
+        <div className="rounded-2xl border border-border/60 bg-card p-4">
+          <div className="mb-3 flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <ShieldAlert className="h-4 w-4 text-muted-foreground" />
+              <span className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">Blocklist Status</span>
+            </div>
+            <span className="text-sm font-semibold">
+              <span className={securityData.blocklist.clean === securityData.blocklist.total ? "text-emerald-400" : "text-red-400"}>
+                {securityData.blocklist.clean}
+              </span>
+              <span className="text-muted-foreground">/{securityData.blocklist.total} clean</span>
+            </span>
+          </div>
+          <div className="mb-3 h-1.5 overflow-hidden rounded-full bg-muted">
+            <div
+              className={`h-full rounded-full transition-all ${securityData.blocklist.clean === securityData.blocklist.total ? "bg-emerald-500" : securityData.blocklist.clean > securityData.blocklist.total / 2 ? "bg-amber-500" : "bg-red-500"}`}
+              style={{ width: `${(securityData.blocklist.clean / securityData.blocklist.total) * 100}%` }}
+            />
+          </div>
+          <div className="grid grid-cols-2 gap-x-4 gap-y-1 sm:grid-cols-3">
+            {securityData.blocklist.results.map((r) => (
+              <div key={r.name} className="flex items-center gap-1.5 text-xs">
+                {r.listed ? (
+                  <ShieldOff className="h-3 w-3 shrink-0 text-red-400" />
+                ) : (
+                  <ShieldCheck className="h-3 w-3 shrink-0 text-emerald-400" />
+                )}
+                <span className={r.listed ? "text-red-400" : "text-muted-foreground"}>{r.name}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/osint/site-identity.tsx
+++ b/src/components/osint/site-identity.tsx
@@ -1,0 +1,196 @@
+"use client"
+
+import { Badge } from "@/components/ui/badge"
+import { Skeleton } from "@/components/ui/skeleton"
+import { Code2, Globe, Cookie, ShieldCheck } from "lucide-react"
+import type { TechStackResult, SocialTagsResult, CookieInfo, IdentityData } from "@/lib/osint-types"
+import Image from "next/image"
+
+interface SiteIdentityProps {
+  techStack: TechStackResult | null
+  socialTags: SocialTagsResult | null
+  cookies: CookieInfo[] | null
+  identityData: IdentityData | null
+  pending: boolean
+  error?: string
+}
+
+const CATEGORY_COLORS: Record<string, string> = {
+  cdn: "bg-amber-950 text-amber-300 border-amber-900",
+  framework: "bg-cyan-950 text-cyan-300 border-cyan-900",
+  cms: "bg-purple-950 text-purple-300 border-purple-900",
+  analytics: "bg-blue-950 text-blue-300 border-blue-900",
+  server: "bg-zinc-800 text-zinc-300 border-zinc-700",
+}
+
+function FlagBadge({ ok, label }: { ok: boolean; label: string }) {
+  return ok ? (
+    <span className="rounded px-1.5 py-0.5 text-xs font-semibold bg-emerald-950 text-emerald-400 border border-emerald-800">{label}</span>
+  ) : (
+    <span className="rounded px-1.5 py-0.5 text-xs font-semibold bg-red-950 text-red-400 border border-red-900">No {label}</span>
+  )
+}
+
+export function SiteIdentity({ techStack, socialTags, cookies, identityData, pending, error }: SiteIdentityProps) {
+  if (error) {
+    return (
+      <div className="rounded-2xl border border-red-900/40 bg-red-950/20 p-4 text-sm text-red-400">
+        Site Identity unavailable: {error}
+      </div>
+    )
+  }
+
+  if (pending) {
+    return (
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        <Skeleton className="h-32 rounded-2xl" />
+        <Skeleton className="h-32 rounded-2xl" />
+        <Skeleton className="col-span-2 h-24 rounded-2xl" />
+      </div>
+    )
+  }
+
+  const hasStack = techStack && Object.values(techStack).some((arr) => arr.length > 0)
+
+  return (
+    <div className="space-y-3">
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        {/* Tech Stack */}
+        <div className="rounded-2xl border border-border/60 bg-card p-4">
+          <div className="mb-3 flex items-center gap-2">
+            <Code2 className="h-4 w-4 text-muted-foreground" />
+            <span className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">Technology Stack</span>
+          </div>
+          {hasStack ? (
+            <div className="space-y-2">
+              {(["cdn", "framework", "cms", "analytics", "server"] as const).map((cat) => {
+                const items = techStack[cat]
+                if (!items.length) return null
+                return (
+                  <div key={cat} className="flex flex-wrap items-center gap-1.5">
+                    <span className="text-xs text-muted-foreground capitalize w-16 shrink-0">{cat}</span>
+                    {items.map((item) => (
+                      <Badge key={item} className={`text-xs ${CATEGORY_COLORS[cat]}`}>{item}</Badge>
+                    ))}
+                  </div>
+                )
+              })}
+            </div>
+          ) : (
+            <div className="text-sm text-muted-foreground">No technology detected</div>
+          )}
+        </div>
+
+        {/* Social Tags */}
+        <div className="rounded-2xl border border-border/60 bg-card p-4">
+          <div className="mb-3 flex items-center gap-2">
+            <Globe className="h-4 w-4 text-muted-foreground" />
+            <span className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">Social Tags</span>
+          </div>
+          {socialTags ? (
+            <div className="space-y-2">
+              {socialTags.og.image && (
+                <div className="relative h-14 w-full overflow-hidden rounded-lg bg-muted">
+                  <Image
+                    src={socialTags.og.image}
+                    alt="OG image"
+                    fill
+                    className="object-cover"
+                    unoptimized
+                  />
+                </div>
+              )}
+              {socialTags.og.title && (
+                <div className="text-sm font-medium line-clamp-1">{socialTags.og.title}</div>
+              )}
+              {socialTags.og.description && (
+                <div className="text-xs text-muted-foreground line-clamp-2">{socialTags.og.description}</div>
+              )}
+              <div className="flex flex-wrap gap-1.5">
+                {socialTags.og.type && (
+                  <Badge variant="outline" className="text-xs">{socialTags.og.type}</Badge>
+                )}
+                {socialTags.twitter.card && (
+                  <Badge variant="outline" className="text-xs">{socialTags.twitter.card}</Badge>
+                )}
+              </div>
+            </div>
+          ) : (
+            <div className="text-sm text-muted-foreground">No social tags found</div>
+          )}
+        </div>
+      </div>
+
+      {/* security.txt */}
+      {identityData && (
+        <div className="rounded-2xl border border-border/60 bg-card p-4">
+          <div className="mb-3 flex items-center gap-2">
+            <ShieldCheck className="h-4 w-4 text-muted-foreground" />
+            <span className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">security.txt</span>
+            {identityData.securityTxt.found ? (
+              <Badge className="ml-auto bg-emerald-950 text-emerald-400 border-emerald-800 text-xs">Found</Badge>
+            ) : (
+              <Badge variant="outline" className="ml-auto text-xs text-muted-foreground">Not Found</Badge>
+            )}
+          </div>
+          {identityData.securityTxt.found && (
+            <div className="grid grid-cols-2 gap-x-6 gap-y-1.5 sm:grid-cols-3">
+              {identityData.securityTxt.contact && (
+                <div>
+                  <div className="text-xs text-muted-foreground">Contact</div>
+                  <div className="truncate text-xs font-mono text-foreground">{identityData.securityTxt.contact}</div>
+                </div>
+              )}
+              {identityData.securityTxt.expires && (
+                <div>
+                  <div className="text-xs text-muted-foreground">Expires</div>
+                  <div className="text-xs text-foreground">{identityData.securityTxt.expires.slice(0, 10)}</div>
+                </div>
+              )}
+              <div>
+                <div className="text-xs text-muted-foreground">Bug Bounty</div>
+                <div className="mt-0.5">
+                  {identityData.securityTxt.bugBounty ? (
+                    <Badge className="bg-emerald-950 text-emerald-400 border-emerald-800 text-xs">Yes</Badge>
+                  ) : (
+                    <Badge variant="outline" className="text-xs text-muted-foreground">No</Badge>
+                  )}
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Cookies */}
+      {cookies && cookies.length > 0 && (
+        <div className="rounded-2xl border border-border/60 bg-card p-4">
+          <div className="mb-3 flex items-center gap-2">
+            <Cookie className="h-4 w-4 text-muted-foreground" />
+            <span className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+              Cookies ({cookies.length})
+            </span>
+          </div>
+          <div className="space-y-2">
+            {cookies.map((cookie, i) => (
+              <div key={i} className="flex flex-wrap items-center justify-between gap-2 border-t border-border/40 pt-2 first:border-t-0 first:pt-0">
+                <span className="font-mono text-xs text-foreground">{cookie.name}</span>
+                <div className="flex flex-wrap gap-1">
+                  <FlagBadge ok={cookie.secure} label="Secure" />
+                  <FlagBadge ok={cookie.httpOnly} label="HttpOnly" />
+                  {cookie.sameSite ? (
+                    <span className={`rounded px-1.5 py-0.5 text-xs font-semibold border ${cookie.sameSite === "None" ? "bg-amber-950 text-amber-400 border-amber-900" : "bg-emerald-950 text-emerald-400 border-emerald-800"}`}>
+                      {cookie.sameSite}
+                    </span>
+                  ) : (
+                    <span className="rounded px-1.5 py-0.5 text-xs font-semibold bg-amber-950 text-amber-400 border border-amber-900">No SameSite</span>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/osint/site-identity.tsx
+++ b/src/components/osint/site-identity.tsx
@@ -90,12 +90,13 @@ export function SiteIdentity({ techStack, socialTags, cookies, identityData, pen
           {socialTags ? (
             <div className="space-y-2">
               {socialTags.og.image && (
-                <div className="relative h-14 w-full overflow-hidden rounded-lg bg-muted">
+                <div className="w-full overflow-hidden rounded-lg bg-muted">
                   <Image
-                    src={socialTags.og.image}
+                    src={`/api/osint/image-proxy?url=${encodeURIComponent(socialTags.og.image)}`}
                     alt="OG image"
-                    fill
-                    className="object-cover"
+                    width={1200}
+                    height={630}
+                    className="w-full h-auto"
                     unoptimized
                   />
                 </div>

--- a/src/components/osint/site-identity.tsx
+++ b/src/components/osint/site-identity.tsx
@@ -92,7 +92,7 @@ export function SiteIdentity({ techStack, socialTags, cookies, identityData, pen
               {socialTags.og.image && (
                 <div className="w-full overflow-hidden rounded-lg bg-muted">
                   <Image
-                    src={`/api/osint/image-proxy?url=${encodeURIComponent(socialTags.og.image)}`}
+                    src={`/api/osint/image-proxy?url=${encodeURIComponent(socialTags.og.image)}&token=${socialTags.og.imageToken ?? ""}`}
                     alt="OG image"
                     width={1200}
                     height={630}

--- a/src/components/osint/threat-history.tsx
+++ b/src/components/osint/threat-history.tsx
@@ -1,0 +1,176 @@
+"use client"
+
+import { Badge } from "@/components/ui/badge"
+import { Skeleton } from "@/components/ui/skeleton"
+import { Server, Archive, FileSearch } from "lucide-react"
+import type { ThreatData } from "@/lib/osint-types"
+
+interface ThreatHistoryProps {
+  threatData: ThreatData | null
+  pending: boolean
+  error?: string
+}
+
+export function ThreatHistory({ threatData, pending, error }: ThreatHistoryProps) {
+  if (error) {
+    return (
+      <div className="rounded-2xl border border-red-900/40 bg-red-950/20 p-4 text-sm text-red-400">
+        Threat & History unavailable: {error}
+      </div>
+    )
+  }
+
+  if (pending || !threatData) {
+    return (
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+        <Skeleton className="h-36 rounded-2xl" />
+        <Skeleton className="h-36 rounded-2xl" />
+        <Skeleton className="h-36 rounded-2xl" />
+      </div>
+    )
+  }
+
+  return (
+    <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+      {/* Shodan */}
+      <div className="rounded-2xl border border-border/60 bg-card p-4">
+        <div className="mb-3 flex items-center gap-2">
+          <Server className="h-4 w-4 text-muted-foreground" />
+          <span className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">Open Ports</span>
+          <span className="ml-auto text-xs text-muted-foreground">Shodan</span>
+        </div>
+        {threatData.shodan.length > 0 ? (
+          <div className="space-y-3">
+            {threatData.shodan.map((host) => (
+              <div key={host.ip}>
+                <div className="mb-1.5 flex items-center justify-between">
+                  <span className="font-mono text-xs text-foreground">{host.ip}</span>
+                  {host.vulns.length > 0 ? (
+                    <Badge className="bg-red-950 text-red-400 border-red-900 text-xs">
+                      {host.vulns.length} CVE{host.vulns.length > 1 ? "s" : ""}
+                    </Badge>
+                  ) : (
+                    <Badge className="bg-emerald-950 text-emerald-400 border-emerald-800 text-xs">0 CVEs</Badge>
+                  )}
+                </div>
+                <div className="flex flex-wrap gap-1">
+                  {host.ports.slice(0, 8).map((port) => (
+                    <span key={port} className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs text-muted-foreground border border-border/60">
+                      {port}
+                    </span>
+                  ))}
+                  {host.ports.length > 8 && (
+                    <span className="text-xs text-muted-foreground">+{host.ports.length - 8}</span>
+                  )}
+                </div>
+                {host.tags.length > 0 && (
+                  <div className="mt-1.5 flex flex-wrap gap-1">
+                    {host.tags.map((tag) => (
+                      <Badge key={tag} variant="outline" className="text-xs">{tag}</Badge>
+                    ))}
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div className="text-sm text-muted-foreground">No Shodan data available</div>
+        )}
+      </div>
+
+      {/* Wayback Machine */}
+      <div className="rounded-2xl border border-border/60 bg-card p-4">
+        <div className="mb-3 flex items-center gap-2">
+          <Archive className="h-4 w-4 text-muted-foreground" />
+          <span className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">Archive</span>
+        </div>
+        {threatData.wayback.available ? (
+          <div className="space-y-3">
+            <div className="grid grid-cols-2 gap-2">
+              <div className="rounded-lg bg-muted/40 p-2 text-center">
+                <div className="text-lg font-bold">{threatData.wayback.firstSeen ?? "—"}</div>
+                <div className="text-xs text-muted-foreground">First seen</div>
+              </div>
+              <div className="rounded-lg bg-muted/40 p-2 text-center">
+                <div className="text-lg font-bold text-emerald-400">
+                  {threatData.wayback.approximateCount != null
+                    ? `${threatData.wayback.approximateCount.toLocaleString()}+`
+                    : "—"}
+                </div>
+                <div className="text-xs text-muted-foreground">Snapshots</div>
+              </div>
+            </div>
+            <div className="flex items-center justify-between text-xs">
+              <span className="text-muted-foreground">Last archived</span>
+              <span>{threatData.wayback.lastArchived ?? "Unknown"}</span>
+            </div>
+            {threatData.wayback.latestUrl && (
+              <a
+                href={threatData.wayback.latestUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1 text-xs text-blue-400 hover:underline"
+              >
+                View latest snapshot ↗
+              </a>
+            )}
+          </div>
+        ) : (
+          <div className="text-sm text-muted-foreground">No archives found</div>
+        )}
+      </div>
+
+      {/* Crawl Rules */}
+      <div className="rounded-2xl border border-border/60 bg-card p-4">
+        <div className="mb-3 flex items-center gap-2">
+          <FileSearch className="h-4 w-4 text-muted-foreground" />
+          <span className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">Crawl Rules</span>
+        </div>
+        <div className="space-y-2">
+          <div className="flex items-center justify-between">
+            <span className="text-xs text-muted-foreground">robots.txt</span>
+            {threatData.crawl.robots.found ? (
+              <Badge className="bg-emerald-950 text-emerald-400 border-emerald-800 text-xs">Found</Badge>
+            ) : (
+              <Badge variant="outline" className="text-xs text-muted-foreground">Not found</Badge>
+            )}
+          </div>
+          {threatData.crawl.robots.found && (
+            <div className="space-y-1 pl-2">
+              <div className="flex justify-between text-xs">
+                <span className="text-muted-foreground">Disallow rules</span>
+                <span>{threatData.crawl.robots.disallowCount}</span>
+              </div>
+              <div className="flex justify-between text-xs">
+                <span className="text-muted-foreground">User-agents</span>
+                <span>{threatData.crawl.robots.userAgentCount}</span>
+              </div>
+            </div>
+          )}
+          <div className="flex items-center justify-between border-t border-border/40 pt-2">
+            <span className="text-xs text-muted-foreground">sitemap.xml</span>
+            {threatData.crawl.sitemap.found ? (
+              <Badge className="bg-emerald-950 text-emerald-400 border-emerald-800 text-xs">Found</Badge>
+            ) : (
+              <Badge variant="outline" className="text-xs text-muted-foreground">Not found</Badge>
+            )}
+          </div>
+          {threatData.crawl.sitemap.found && (
+            <div className="space-y-1 pl-2">
+              <div className="flex justify-between text-xs">
+                <span className="text-muted-foreground">URLs listed</span>
+                <span>{threatData.crawl.sitemap.urlCount.toLocaleString()}</span>
+              </div>
+              {threatData.crawl.sitemap.lastModified && (
+                <div className="flex justify-between text-xs">
+                  <span className="text-muted-foreground">Last modified</span>
+                  <span>{threatData.crawl.sitemap.lastModified}</span>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/whois-lookup.tsx
+++ b/src/components/whois-lookup.tsx
@@ -55,6 +55,9 @@ export function WhoisLookup() {
   const [pending, setPending] = useState<Record<string, boolean>>({})
   const [certDnsData, setCertDnsData] = useState<Record<string, any> | null>(null)
   const [certDnsPending, setCertDnsPending] = useState<Record<string, boolean>>({})
+  const [securityData, setSecurityData] = useState<any>(null)
+  const [identityData, setIdentityData] = useState<any>(null)
+  const [threatData, setThreatData] = useState<any>(null)
   const [copied, setCopied] = useState(false)
   const hasAutoSearched = useRef(false)
   const prevUrlQuery = useRef(initialQuery)
@@ -83,6 +86,9 @@ export function WhoisLookup() {
       setPending({})
       setCertDnsData(null)
       setCertDnsPending({})
+      setSecurityData(null)
+      setIdentityData(null)
+      setThreatData(null)
 
       // Update URL with query parameter
       if (updateUrl) {
@@ -117,6 +123,9 @@ export function WhoisLookup() {
             { key: "http", promise: fetchJson(`/api/osint/http?target=${encodeURIComponent(trimmed)}`) },
             { key: "certs", promise: fetchJson(`/api/osint/certificates?target=${encodeURIComponent(trimmed)}`) },
             { key: "ip", promise: fetchJson(`/api/ip?target=${encodeURIComponent(trimmed)}&details=true`) },
+            { key: "security", promise: fetchJson(`/api/osint/security?target=${encodeURIComponent(trimmed)}`) },
+            { key: "identity", promise: fetchJson(`/api/osint/identity?target=${encodeURIComponent(trimmed)}`) },
+            { key: "threat", promise: fetchJson(`/api/osint/threat?target=${encodeURIComponent(trimmed)}`) },
           )
         }
 
@@ -124,6 +133,8 @@ export function WhoisLookup() {
           tasks.push(
             { key: "http", promise: fetchJson(`/api/osint/http?target=${encodeURIComponent(trimmed)}`) },
             { key: "ip", promise: fetchJson(`/api/ip?target=${encodeURIComponent(trimmed)}&details=true`) },
+            { key: "security", promise: fetchJson(`/api/osint/security?target=${encodeURIComponent(trimmed)}`) },
+            { key: "threat", promise: fetchJson(`/api/osint/threat?target=${encodeURIComponent(trimmed)}`) },
           )
         }
 
@@ -146,6 +157,9 @@ export function WhoisLookup() {
               if (task.key === "http") setHttpData(value)
               if (task.key === "certs") setCertData(value)
               if (task.key === "ip") setIpData(value)
+              if (task.key === "security") setSecurityData(value)
+              if (task.key === "identity") setIdentityData(value)
+              if (task.key === "threat") setThreatData(value)
             })
             .catch((err) => {
               setOsintErrors((prev) => ({
@@ -201,6 +215,9 @@ export function WhoisLookup() {
         setPending({})
         setCertDnsData(null)
         setCertDnsPending({})
+        setSecurityData(null)
+        setIdentityData(null)
+        setThreatData(null)
         setError(null)
       }
     }
@@ -362,6 +379,9 @@ export function WhoisLookup() {
             httpData={httpData}
             certData={certData}
             ipData={ipData}
+            securityData={securityData}
+            identityData={identityData}
+            threatData={threatData}
             query={query}
             errors={osintErrors}
             pending={pending}

--- a/src/components/whois-lookup.tsx
+++ b/src/components/whois-lookup.tsx
@@ -11,6 +11,7 @@ import type React from "react"
 import { Spinner } from "@/components/ui/spinner"
 import { OsintResults } from "@/components/osint-results"
 import { useHaptics } from "@/hooks/use-haptics"
+import type { SecurityData, IdentityData, ThreatData } from "@/lib/osint-types"
 
 const EXAMPLE_QUERIES = [
   { label: "google.com", icon: Globe, type: "domain" },
@@ -55,9 +56,9 @@ export function WhoisLookup() {
   const [pending, setPending] = useState<Record<string, boolean>>({})
   const [certDnsData, setCertDnsData] = useState<Record<string, any> | null>(null)
   const [certDnsPending, setCertDnsPending] = useState<Record<string, boolean>>({})
-  const [securityData, setSecurityData] = useState<any>(null)
-  const [identityData, setIdentityData] = useState<any>(null)
-  const [threatData, setThreatData] = useState<any>(null)
+  const [securityData, setSecurityData] = useState<SecurityData | null>(null)
+  const [identityData, setIdentityData] = useState<IdentityData | null>(null)
+  const [threatData, setThreatData] = useState<ThreatData | null>(null)
   const [copied, setCopied] = useState(false)
   const hasAutoSearched = useRef(false)
   const prevUrlQuery = useRef(initialQuery)
@@ -146,6 +147,9 @@ export function WhoisLookup() {
         if (!requestedKeys.has("http")) baselineErrors.http = "Not applicable for this query type"
         if (!requestedKeys.has("certs")) baselineErrors.certs = "Not applicable for this query type"
         if (!requestedKeys.has("ip")) baselineErrors.ip = "Not applicable for this query type"
+        if (!requestedKeys.has("security")) baselineErrors.security = "Not applicable for this query type"
+        if (!requestedKeys.has("identity")) baselineErrors.identity = "Not applicable for this query type"
+        if (!requestedKeys.has("threat")) baselineErrors.threat = "Not applicable for this query type"
         setOsintErrors(baselineErrors)
 
         const taskPromises = tasks.map((task) => task.promise)
@@ -280,7 +284,7 @@ export function WhoisLookup() {
     performLookup(example)
   }
 
-  const hasResults = Boolean(rdapData || dnsData || httpData || certData || ipData)
+  const hasResults = Boolean(rdapData || dnsData || httpData || certData || ipData || securityData || identityData || threatData)
 
   return (
     <div className="space-y-8">

--- a/src/lib/email-security.test.ts
+++ b/src/lib/email-security.test.ts
@@ -33,4 +33,17 @@ describe("parseEmailSecurity", () => {
     const result = parseEmailSecurity(["v=BIMI1; l=https://example.com/logo.svg"])
     expect(result.bimi.present).toBe(true)
   })
+
+  test("defaults pct to 100 when tag is absent", () => {
+    const result = parseEmailSecurity(["v=DMARC1; p=quarantine; rua=mailto:x@example.com"])
+    expect(result.dmarc.pct).toBe(100)
+  })
+
+  test("returns all nulls/none/false for empty array", () => {
+    const result = parseEmailSecurity([])
+    expect(result.spf.record).toBeNull()
+    expect(result.spf.policy).toBe("none")
+    expect(result.dmarc.record).toBeNull()
+    expect(result.bimi.present).toBe(false)
+  })
 })

--- a/src/lib/email-security.test.ts
+++ b/src/lib/email-security.test.ts
@@ -1,0 +1,36 @@
+// src/lib/email-security.test.ts
+import { describe, test, expect } from "bun:test"
+import { parseEmailSecurity } from "./email-security"
+
+describe("parseEmailSecurity", () => {
+  test("parses SPF with -all policy", () => {
+    const result = parseEmailSecurity(["v=spf1 include:_spf.google.com -all"])
+    expect(result.spf.policy).toBe("fail")
+    expect(result.spf.record).toBe("v=spf1 include:_spf.google.com -all")
+  })
+
+  test("parses SPF with ~all policy", () => {
+    const result = parseEmailSecurity(["v=spf1 include:sendgrid.net ~all"])
+    expect(result.spf.policy).toBe("softfail")
+  })
+
+  test("parses DMARC p=reject", () => {
+    const result = parseEmailSecurity([
+      "v=DMARC1; p=reject; rua=mailto:dmarc@example.com; pct=100",
+    ])
+    expect(result.dmarc.policy).toBe("reject")
+    expect(result.dmarc.reporting).toBe(true)
+    expect(result.dmarc.pct).toBe(100)
+  })
+
+  test("returns none when no SPF record", () => {
+    const result = parseEmailSecurity(["v=DMARC1; p=none"])
+    expect(result.spf.policy).toBe("none")
+    expect(result.spf.record).toBeNull()
+  })
+
+  test("detects BIMI record", () => {
+    const result = parseEmailSecurity(["v=BIMI1; l=https://example.com/logo.svg"])
+    expect(result.bimi.present).toBe(true)
+  })
+})

--- a/src/lib/email-security.test.ts
+++ b/src/lib/email-security.test.ts
@@ -1,4 +1,3 @@
-// src/lib/email-security.test.ts
 import { describe, test, expect } from "bun:test"
 import { parseEmailSecurity } from "./email-security"
 

--- a/src/lib/email-security.ts
+++ b/src/lib/email-security.ts
@@ -1,8 +1,13 @@
 // src/lib/email-security.ts
 import type { EmailSecurityResult } from "./osint-types"
 
+function stripTxtQuotes(r: string): string {
+  return r.startsWith('"') && r.endsWith('"') ? r.slice(1, -1) : r
+}
+
 export function parseEmailSecurity(txtRecords: string[]): EmailSecurityResult {
-  const spfRecord = txtRecords.find((r) => r.startsWith("v=spf1")) ?? null
+  const records = txtRecords.map(stripTxtQuotes)
+  const spfRecord = records.find((r) => r.startsWith("v=spf1")) ?? null
   const spfPolicy: EmailSecurityResult["spf"]["policy"] = spfRecord?.includes("-all")
     ? "fail"
     : spfRecord?.includes("~all")
@@ -14,7 +19,7 @@ export function parseEmailSecurity(txtRecords: string[]): EmailSecurityResult {
             "neutral"
           : "none"
 
-  const dmarcRecord = txtRecords.find((r) => r.startsWith("v=DMARC1")) ?? null
+  const dmarcRecord = records.find((r) => r.startsWith("v=DMARC1")) ?? null
   const dmarcPolicyRaw = dmarcRecord?.match(/p=(none|quarantine|reject)/)?.[1]
   const dmarcPolicyMap: Record<string, EmailSecurityResult["dmarc"]["policy"]> = {
     none: "none",
@@ -23,7 +28,7 @@ export function parseEmailSecurity(txtRecords: string[]): EmailSecurityResult {
   }
   const dmarcPct = parseInt(dmarcRecord?.match(/pct=(\d+)/)?.[1] ?? "100", 10)
 
-  const bimiRecord = txtRecords.find((r) => r.startsWith("v=BIMI1")) ?? null
+  const bimiRecord = records.find((r) => r.startsWith("v=BIMI1")) ?? null
 
   return {
     spf: {

--- a/src/lib/email-security.ts
+++ b/src/lib/email-security.ts
@@ -1,4 +1,3 @@
-// src/lib/email-security.ts
 import type { EmailSecurityResult } from "./osint-types"
 
 function stripTxtQuotes(r: string): string {

--- a/src/lib/email-security.ts
+++ b/src/lib/email-security.ts
@@ -1,0 +1,38 @@
+// src/lib/email-security.ts
+import type { EmailSecurityResult } from "./osint-types"
+
+export function parseEmailSecurity(txtRecords: string[]): EmailSecurityResult {
+  const spfRecord = txtRecords.find((r) => r.startsWith("v=spf1")) ?? null
+  const spfPolicy = spfRecord?.includes("-all")
+    ? "fail"
+    : spfRecord?.includes("~all")
+      ? "softfail"
+      : spfRecord?.includes("?all")
+        ? "neutral"
+        : spfRecord
+          ? "neutral"
+          : "none"
+
+  const dmarcRecord = txtRecords.find((r) => r.startsWith("v=DMARC1")) ?? null
+  const dmarcPolicyMatch = dmarcRecord?.match(/p=(none|quarantine|reject)/)
+  const dmarcPct = parseInt(dmarcRecord?.match(/pct=(\d+)/)?.[1] ?? "100", 10)
+
+  const bimiRecord = txtRecords.find((r) => r.startsWith("v=BIMI1")) ?? null
+
+  return {
+    spf: {
+      record: spfRecord,
+      policy: (spfPolicy) as EmailSecurityResult["spf"]["policy"],
+    },
+    dmarc: {
+      record: dmarcRecord,
+      policy: (dmarcPolicyMatch?.[1] ?? "none") as EmailSecurityResult["dmarc"]["policy"],
+      reporting: dmarcRecord?.includes("rua=") ?? false,
+      pct: isNaN(dmarcPct) ? 100 : dmarcPct,
+    },
+    bimi: {
+      present: bimiRecord !== null,
+      record: bimiRecord,
+    },
+  }
+}

--- a/src/lib/email-security.ts
+++ b/src/lib/email-security.ts
@@ -3,18 +3,24 @@ import type { EmailSecurityResult } from "./osint-types"
 
 export function parseEmailSecurity(txtRecords: string[]): EmailSecurityResult {
   const spfRecord = txtRecords.find((r) => r.startsWith("v=spf1")) ?? null
-  const spfPolicy = spfRecord?.includes("-all")
+  const spfPolicy: EmailSecurityResult["spf"]["policy"] = spfRecord?.includes("-all")
     ? "fail"
     : spfRecord?.includes("~all")
       ? "softfail"
       : spfRecord?.includes("?all")
         ? "neutral"
         : spfRecord
-          ? "neutral"
+          ? // +all and bare 'all' have no "pass" variant in the policy union; treat as neutral (permissive but not specifically harmful)
+            "neutral"
           : "none"
 
   const dmarcRecord = txtRecords.find((r) => r.startsWith("v=DMARC1")) ?? null
-  const dmarcPolicyMatch = dmarcRecord?.match(/p=(none|quarantine|reject)/)
+  const dmarcPolicyRaw = dmarcRecord?.match(/p=(none|quarantine|reject)/)?.[1]
+  const dmarcPolicyMap: Record<string, EmailSecurityResult["dmarc"]["policy"]> = {
+    none: "none",
+    quarantine: "quarantine",
+    reject: "reject",
+  }
   const dmarcPct = parseInt(dmarcRecord?.match(/pct=(\d+)/)?.[1] ?? "100", 10)
 
   const bimiRecord = txtRecords.find((r) => r.startsWith("v=BIMI1")) ?? null
@@ -22,11 +28,11 @@ export function parseEmailSecurity(txtRecords: string[]): EmailSecurityResult {
   return {
     spf: {
       record: spfRecord,
-      policy: (spfPolicy) as EmailSecurityResult["spf"]["policy"],
+      policy: spfPolicy,
     },
     dmarc: {
       record: dmarcRecord,
-      policy: (dmarcPolicyMatch?.[1] ?? "none") as EmailSecurityResult["dmarc"]["policy"],
+      policy: dmarcPolicyMap[dmarcPolicyRaw ?? ""] ?? "none",
       reporting: dmarcRecord?.includes("rua=") ?? false,
       pct: isNaN(dmarcPct) ? 100 : dmarcPct,
     },

--- a/src/lib/osint-image-sign.ts
+++ b/src/lib/osint-image-sign.ts
@@ -1,0 +1,27 @@
+const SECRET = process.env.OG_SECRET ?? ""
+
+async function importKey(secret: string): Promise<CryptoKey> {
+  return crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(secret || "dev-insecure-fallback"),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign", "verify"],
+  )
+}
+
+export async function signImageUrl(url: string): Promise<string> {
+  const key = await importKey(SECRET)
+  const sig = await crypto.subtle.sign("HMAC", key, new TextEncoder().encode(url))
+  return Buffer.from(sig).toString("hex")
+}
+
+export async function verifyImageUrl(url: string, token: string): Promise<boolean> {
+  try {
+    const key = await importKey(SECRET)
+    const expected = Buffer.from(token, "hex")
+    return crypto.subtle.verify("HMAC", key, expected, new TextEncoder().encode(url))
+  } catch {
+    return false
+  }
+}

--- a/src/lib/osint-types.ts
+++ b/src/lib/osint-types.ts
@@ -1,0 +1,120 @@
+export interface EmailSecurityResult {
+  spf: {
+    record: string | null
+    policy: "fail" | "softfail" | "neutral" | "none"
+  }
+  dmarc: {
+    record: string | null
+    policy: "none" | "quarantine" | "reject"
+    reporting: boolean
+    pct: number
+  }
+  bimi: {
+    present: boolean
+    record: string | null
+  }
+}
+
+export interface WAFResult {
+  detected: boolean
+  name: string | null
+  capabilities: string[]
+}
+
+export interface TechStackResult {
+  cdn: string[]
+  framework: string[]
+  cms: string[]
+  analytics: string[]
+  server: string[]
+}
+
+export interface SocialTagsResult {
+  og: {
+    title: string | null
+    description: string | null
+    image: string | null
+    type: string | null
+    siteName: string | null
+  }
+  twitter: {
+    card: string | null
+    site: string | null
+    creator: string | null
+  }
+}
+
+export interface CookieInfo {
+  name: string
+  domain: string | null
+  path: string | null
+  secure: boolean
+  httpOnly: boolean
+  sameSite: "Strict" | "Lax" | "None" | null
+  expires: string | null
+}
+
+export interface RedirectHop {
+  url: string
+  status: number
+  latencyMs: number
+}
+
+export interface SecurityData {
+  dnssec: {
+    enabled: boolean
+    algorithm: string | null
+  }
+  dkim: {
+    selectors: string[]
+  }
+  blocklist: {
+    total: number
+    clean: number
+    results: Array<{ name: string; listed: boolean }>
+  }
+}
+
+export interface IdentityData {
+  securityTxt: {
+    found: boolean
+    contact: string | null
+    expires: string | null
+    policy: string | null
+    encryption: string | null
+    acknowledgments: string | null
+    hiring: string | null
+    bugBounty: boolean
+  }
+}
+
+export interface ShodanHostInfo {
+  ip: string
+  ports: number[]
+  vulns: string[]
+  tags: string[]
+}
+
+export interface ThreatData {
+  shodan: ShodanHostInfo[]
+  wayback: {
+    available: boolean
+    firstSeen: string | null
+    lastArchived: string | null
+    latestUrl: string | null
+    approximateCount: number | null
+  }
+  crawl: {
+    robots: {
+      found: boolean
+      disallowCount: number
+      userAgentCount: number
+      sitemapUrls: string[]
+    }
+    sitemap: {
+      found: boolean
+      urlCount: number
+      lastModified: string | null
+    }
+  }
+}

--- a/src/lib/osint-types.ts
+++ b/src/lib/osint-types.ts
@@ -67,6 +67,7 @@ export interface SecurityData {
   }
   dkim: {
     selectors: string[]
+    wildcard: boolean
   }
   blocklist: {
     total: number

--- a/src/lib/osint-types.ts
+++ b/src/lib/osint-types.ts
@@ -34,6 +34,7 @@ export interface SocialTagsResult {
     title: string | null
     description: string | null
     image: string | null
+    imageToken: string | null
     type: string | null
     siteName: string | null
   }

--- a/src/lib/social-tags.ts
+++ b/src/lib/social-tags.ts
@@ -1,0 +1,32 @@
+import type { SocialTagsResult } from "./osint-types"
+
+function getMeta(html: string, property: string): string | null {
+  const patterns = [
+    new RegExp(`<meta[^>]+property=["']${property}["'][^>]+content=["']([^"']*)["']`, "i"),
+    new RegExp(`<meta[^>]+content=["']([^"']*)["'][^>]+property=["']${property}["']`, "i"),
+    new RegExp(`<meta[^>]+name=["']${property}["'][^>]+content=["']([^"']*)["']`, "i"),
+    new RegExp(`<meta[^>]+content=["']([^"']*)["'][^>]+name=["']${property}["']`, "i"),
+  ]
+  for (const pattern of patterns) {
+    const match = html.match(pattern)
+    if (match?.[1]) return match[1].trim()
+  }
+  return null
+}
+
+export function parseSocialTags(html: string): SocialTagsResult {
+  return {
+    og: {
+      title: getMeta(html, "og:title"),
+      description: getMeta(html, "og:description"),
+      image: getMeta(html, "og:image"),
+      type: getMeta(html, "og:type"),
+      siteName: getMeta(html, "og:site_name"),
+    },
+    twitter: {
+      card: getMeta(html, "twitter:card"),
+      site: getMeta(html, "twitter:site"),
+      creator: getMeta(html, "twitter:creator"),
+    },
+  }
+}

--- a/src/lib/social-tags.ts
+++ b/src/lib/social-tags.ts
@@ -28,6 +28,7 @@ export function parseSocialTags(html: string): SocialTagsResult {
       title: getMeta(html, "og:title"),
       description: getMeta(html, "og:description"),
       image: getMeta(html, "og:image"),
+      imageToken: null,
       type: getMeta(html, "og:type"),
       siteName: getMeta(html, "og:site_name"),
     },

--- a/src/lib/social-tags.ts
+++ b/src/lib/social-tags.ts
@@ -1,5 +1,13 @@
 import type { SocialTagsResult } from "./osint-types"
 
+const HTML_ENTITIES: Record<string, string> = {
+  "&amp;": "&", "&lt;": "<", "&gt;": ">", "&quot;": '"', "&#39;": "'", "&#x27;": "'",
+}
+
+function decodeEntities(s: string): string {
+  return s.replace(/&(?:amp|lt|gt|quot|#39|#x27);/gi, (m) => HTML_ENTITIES[m.toLowerCase()] ?? m)
+}
+
 function getMeta(html: string, property: string): string | null {
   const patterns = [
     new RegExp(`<meta[^>]+property=["']${property}["'][^>]+content=["']([^"']*)["']`, "i"),
@@ -9,7 +17,7 @@ function getMeta(html: string, property: string): string | null {
   ]
   for (const pattern of patterns) {
     const match = html.match(pattern)
-    if (match?.[1]) return match[1].trim()
+    if (match?.[1]) return decodeEntities(match[1].trim())
   }
   return null
 }

--- a/src/lib/tech-stack.ts
+++ b/src/lib/tech-stack.ts
@@ -1,0 +1,73 @@
+import type { TechStackResult } from "./osint-types"
+
+export function detectTechStack(
+  headers: Record<string, string>,
+  html: string
+): TechStackResult {
+  const result: TechStackResult = { cdn: [], framework: [], cms: [], analytics: [], server: [] }
+  const h = (k: string) => headers[k.toLowerCase()] ?? ""
+
+  // CDN / Hosting
+  if (h("cf-ray") || h("server").includes("cloudflare")) result.cdn.push("Cloudflare")
+  if (h("x-vercel-id") || h("x-vercel-cache")) result.cdn.push("Vercel")
+  if (h("x-amz-cf-id") || h("via").includes("cloudfront")) result.cdn.push("AWS CloudFront")
+  if (h("x-served-by") && !result.cdn.includes("Fastly")) result.cdn.push("Fastly")
+  if (h("x-github-request-id")) result.cdn.push("GitHub Pages")
+  if (h("x-netlify-cache") || h("x-nf-request-id")) result.cdn.push("Netlify")
+
+  // Server
+  const server = h("server")
+  if (server.includes("nginx")) result.server.push("nginx")
+  else if (server.includes("apache")) result.server.push("Apache")
+  else if (server.includes("caddy")) result.server.push("Caddy")
+  else if (server.includes("iis")) result.server.push("IIS")
+
+  const poweredBy = h("x-powered-by")
+  if (poweredBy.includes("next.js")) result.framework.push("Next.js")
+  else if (poweredBy.includes("express")) result.server.push("Express")
+  else if (poweredBy.includes("php")) result.server.push("PHP")
+
+  // Framework — HTML patterns
+  if (html.includes("/_next/static/") || html.includes("__NEXT_DATA__")) {
+    if (!result.framework.includes("Next.js")) result.framework.push("Next.js")
+  }
+  if (html.includes("/wp-content/") || html.includes("/wp-includes/")) result.cms.push("WordPress")
+  if (html.includes("gatsby-")) result.framework.push("Gatsby")
+  if (html.includes("__nuxt") || html.includes("/_nuxt/")) result.framework.push("Nuxt")
+  if (html.includes("data-astro-") || html.includes("/_astro/")) result.framework.push("Astro")
+  if (html.includes("ng-version=") || html.includes("ng-app")) result.framework.push("Angular")
+  if (html.includes("data-reactroot") || html.includes("react-dom")) {
+    if (!result.framework.some((f) => ["Next.js", "Gatsby", "Nuxt"].includes(f))) {
+      result.framework.push("React")
+    }
+  }
+
+  // CMS
+  const generator = html.match(/<meta[^>]+name=["']generator["'][^>]+content=["']([^"']+)["']/i)?.[1] ?? ""
+  if (generator) {
+    if (generator.toLowerCase().includes("wordpress")) result.cms.push("WordPress")
+    else if (generator.toLowerCase().includes("drupal")) result.cms.push("Drupal")
+    else if (generator.toLowerCase().includes("joomla")) result.cms.push("Joomla")
+    else if (generator.toLowerCase().includes("ghost")) result.cms.push("Ghost")
+    else if (generator.toLowerCase().includes("shopify")) result.cms.push("Shopify")
+  }
+  if (html.includes("Shopify.theme") || h("x-shopid")) {
+    if (!result.cms.includes("Shopify")) result.cms.push("Shopify")
+  }
+
+  // Analytics
+  if (html.includes("google-analytics.com") || html.includes("gtag(") || html.includes("GoogleAnalyticsObject")) result.analytics.push("Google Analytics")
+  if (html.includes("plausible.io") || html.includes('data-domain')) result.analytics.push("Plausible")
+  if (html.includes("fathom") && html.includes("cdn.usefathom.com")) result.analytics.push("Fathom")
+  if (html.includes("hotjar.com")) result.analytics.push("Hotjar")
+  if (html.includes("segment.com/analytics.js")) result.analytics.push("Segment")
+
+  // Deduplicate
+  return {
+    cdn: [...new Set(result.cdn)],
+    framework: [...new Set(result.framework)],
+    cms: [...new Set(result.cms)],
+    analytics: [...new Set(result.analytics)],
+    server: [...new Set(result.server)],
+  }
+}

--- a/src/lib/tech-stack.ts
+++ b/src/lib/tech-stack.ts
@@ -11,7 +11,7 @@ export function detectTechStack(
   if (h("cf-ray") || h("server").includes("cloudflare")) result.cdn.push("Cloudflare")
   if (h("x-vercel-id") || h("x-vercel-cache")) result.cdn.push("Vercel")
   if (h("x-amz-cf-id") || h("via").includes("cloudfront")) result.cdn.push("AWS CloudFront")
-  if (h("x-served-by") && !result.cdn.includes("Fastly")) result.cdn.push("Fastly")
+  if (h("x-served-by") || h("fastly-restarts")) result.cdn.push("Fastly")
   if (h("x-github-request-id")) result.cdn.push("GitHub Pages")
   if (h("x-netlify-cache") || h("x-nf-request-id")) result.cdn.push("Netlify")
 
@@ -42,7 +42,12 @@ export function detectTechStack(
     }
   }
 
-  // CMS
+  // CMS — x-generator header + meta generator tag
+  const xGenerator = h("x-generator").toLowerCase()
+  if (xGenerator.includes("wordpress")) result.cms.push("WordPress")
+  else if (xGenerator.includes("drupal")) result.cms.push("Drupal")
+  else if (xGenerator.includes("joomla")) result.cms.push("Joomla")
+
   const generator = html.match(/<meta[^>]+name=["']generator["'][^>]+content=["']([^"']+)["']/i)?.[1] ?? ""
   if (generator) {
     if (generator.toLowerCase().includes("wordpress")) result.cms.push("WordPress")
@@ -57,7 +62,7 @@ export function detectTechStack(
 
   // Analytics
   if (html.includes("google-analytics.com") || html.includes("gtag(") || html.includes("GoogleAnalyticsObject")) result.analytics.push("Google Analytics")
-  if (html.includes("plausible.io") || html.includes('data-domain')) result.analytics.push("Plausible")
+  if (html.includes("plausible.io")) result.analytics.push("Plausible")
   if (html.includes("fathom") && html.includes("cdn.usefathom.com")) result.analytics.push("Fathom")
   if (html.includes("hotjar.com")) result.analytics.push("Hotjar")
   if (html.includes("segment.com/analytics.js")) result.analytics.push("Segment")

--- a/src/lib/waf-detector.test.ts
+++ b/src/lib/waf-detector.test.ts
@@ -1,0 +1,30 @@
+// src/lib/waf-detector.test.ts
+import { describe, test, expect } from "bun:test"
+import { detectWAF } from "./waf-detector"
+
+describe("detectWAF", () => {
+  test("detects Cloudflare from cf-ray header", () => {
+    const result = detectWAF({ "cf-ray": "abc123-LHR", "server": "cloudflare" })
+    expect(result.detected).toBe(true)
+    expect(result.name).toBe("Cloudflare")
+    expect(result.capabilities).toContain("CDN")
+  })
+
+  test("detects AWS CloudFront", () => {
+    const result = detectWAF({ "x-amz-cf-id": "abc123", "via": "1.1 cloudfront.net" })
+    expect(result.detected).toBe(true)
+    expect(result.name).toBe("AWS CloudFront")
+  })
+
+  test("detects Fastly", () => {
+    const result = detectWAF({ "x-served-by": "cache-lhr-egll1234-LHR", "x-cache": "HIT" })
+    expect(result.detected).toBe(true)
+    expect(result.name).toBe("Fastly")
+  })
+
+  test("returns not detected for unknown headers", () => {
+    const result = detectWAF({ "server": "nginx", "content-type": "text/html" })
+    expect(result.detected).toBe(false)
+    expect(result.name).toBeNull()
+  })
+})

--- a/src/lib/waf-detector.test.ts
+++ b/src/lib/waf-detector.test.ts
@@ -1,4 +1,3 @@
-// src/lib/waf-detector.test.ts
 import { describe, test, expect } from "bun:test"
 import { detectWAF } from "./waf-detector"
 

--- a/src/lib/waf-detector.ts
+++ b/src/lib/waf-detector.ts
@@ -1,4 +1,3 @@
-// src/lib/waf-detector.ts
 import type { WAFResult } from "./osint-types"
 
 interface WAFSignature {

--- a/src/lib/waf-detector.ts
+++ b/src/lib/waf-detector.ts
@@ -1,0 +1,69 @@
+// src/lib/waf-detector.ts
+import type { WAFResult } from "./osint-types"
+
+interface WAFSignature {
+  name: string
+  capabilities: string[]
+  headers: Array<{ key: string; value?: string | RegExp }>
+}
+
+const SIGNATURES: WAFSignature[] = [
+  {
+    name: "Cloudflare",
+    capabilities: ["WAF", "CDN", "DDoS Protection"],
+    headers: [{ key: "cf-ray" }, { key: "server", value: "cloudflare" }],
+  },
+  {
+    name: "AWS CloudFront",
+    capabilities: ["CDN"],
+    headers: [{ key: "x-amz-cf-id" }, { key: "via", value: /cloudfront/ }],
+  },
+  {
+    name: "Fastly",
+    capabilities: ["CDN"],
+    headers: [{ key: "x-served-by" }, { key: "fastly-restarts" }],
+  },
+  {
+    name: "Akamai",
+    capabilities: ["WAF", "CDN", "DDoS Protection"],
+    headers: [{ key: "x-akamai-transformed" }, { key: "akamai-cache-status" }],
+  },
+  {
+    name: "Imperva",
+    capabilities: ["WAF"],
+    headers: [{ key: "x-iinfo" }, { key: "x-cdn", value: /Incapsula/i }],
+  },
+  {
+    name: "Sucuri",
+    capabilities: ["WAF"],
+    headers: [{ key: "x-sucuri-id" }, { key: "x-sucuri-cache" }],
+  },
+  {
+    name: "Vercel",
+    capabilities: ["CDN"],
+    headers: [{ key: "x-vercel-id" }, { key: "x-vercel-cache" }],
+  },
+]
+
+export function detectWAF(headers: Record<string, string>): WAFResult {
+  const lowerHeaders: Record<string, string> = {}
+  for (const [k, v] of Object.entries(headers)) {
+    lowerHeaders[k.toLowerCase()] = v.toLowerCase()
+  }
+
+  for (const sig of SIGNATURES) {
+    const matched = sig.headers.some((h) => {
+      const val = lowerHeaders[h.key.toLowerCase()]
+      if (!val) return false
+      if (!h.value) return true
+      if (h.value instanceof RegExp) return h.value.test(val)
+      return val.includes(h.value.toLowerCase())
+    })
+
+    if (matched) {
+      return { detected: true, name: sig.name, capabilities: sig.capabilities }
+    }
+  }
+
+  return { detected: false, name: null, capabilities: [] }
+}

--- a/src/types/bun-env.d.ts
+++ b/src/types/bun-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="bun-types" />


### PR DESCRIPTION
## Summary

- **Security Posture** — WAF/CDN detection, DNSSEC (with algorithm), DKIM (per-selector or wildcard detection), SPF/DMARC/BIMI email authentication, and domain/IP blocklist status (Spamhaus, SURBL, SpamCop, etc.)
- **Site Identity** — tech stack fingerprinting (CDN, framework, CMS, analytics), OG/Twitter social tags with proxied image preview, cookie inventory, and security.txt disclosure
- **Threat & History** — Shodan InternetDB open ports/CVEs/tags, Wayback Machine archive history, robots.txt and sitemap crawl rules
- **Redirect Chain tab** — step-by-step redirect hops with status codes and open-redirect detection, added to the Web Fingerprint section

## Implementation details

- Three new zero-API-key API routes: `/api/osint/security`, `/api/osint/identity`, `/api/osint/threat`
- HTTP route extended with WAF detection, tech stack parsing, social tag extraction, cookie inventory, and redirect chain tracking
- DNS route extended with SPF/DMARC/BIMI parsing (queries `_dmarc.{domain}` correctly)
- OG image preview proxied through `/api/osint/image-proxy` (CSP-safe, HMAC-signed with `OG_SECRET` to prevent open proxy abuse)
- DKIM wildcard detection via nonsense-selector probe to avoid false positives from `*._domainkey.domain` records
- TXT record quote-stripping for Cloudflare DoH responses