### PR TITLE
feat(mdx): add Callout, Accent, References components with animations

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -601,10 +601,16 @@
 .blog-prose .mdx-cite a {
   color: inherit;
   text-decoration: none;
+  transition: color 0.15s ease, text-shadow 0.15s ease;
 }
 
 .blog-prose .mdx-cite a:hover {
   color: var(--color-foreground);
+  text-shadow: 0 0 8px color-mix(in srgb, var(--color-foreground) 40%, transparent);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .blog-prose .mdx-cite a { transition: none; }
 }
 
 .blog-prose .mdx-cite:target {
@@ -789,11 +795,54 @@
  * surrounding padding region) doesn't get clipped.
  */
 
+.mdx-margin-note,
+.mdx-margin-enclose {
+  --mn-color: color-mix(in srgb, var(--color-foreground) 78%, transparent);
+}
+
+.mdx-margin-note[data-color="info"],
+.mdx-margin-enclose[data-color="info"],
+.mdx-accent[data-color="info"] {
+  --mn-color: oklch(50% 0.18 250);
+  :is(.dark *) & { --mn-color: oklch(68% 0.18 250); }
+}
+.mdx-margin-note[data-color="tip"],
+.mdx-margin-enclose[data-color="tip"],
+.mdx-accent[data-color="tip"] {
+  --mn-color: oklch(48% 0.17 155);
+  :is(.dark *) & { --mn-color: oklch(65% 0.17 155); }
+}
+.mdx-margin-note[data-color="warning"],
+.mdx-margin-enclose[data-color="warning"],
+.mdx-accent[data-color="warning"] {
+  --mn-color: oklch(58% 0.16 75);
+  :is(.dark *) & { --mn-color: oklch(74% 0.16 75); }
+}
+.mdx-margin-note[data-color="danger"],
+.mdx-margin-enclose[data-color="danger"],
+.mdx-accent[data-color="danger"] {
+  --mn-color: oklch(50% 0.22 25);
+  :is(.dark *) & { --mn-color: oklch(68% 0.22 25); }
+}
+.mdx-margin-note[data-color="purple"],
+.mdx-margin-enclose[data-color="purple"],
+.mdx-accent[data-color="purple"] {
+  --mn-color: oklch(50% 0.22 300);
+  :is(.dark *) & { --mn-color: oklch(68% 0.22 300); }
+}
+
+/* Inline accent — colour only, no font change. Falls back to inherited colour
+   when no data-color is set (var() on an undefined custom property resolves to
+   inherit for inherited properties like color). */
+.mdx-accent {
+  color: var(--mn-color);
+}
+
 .mdx-margin-note {
   position: relative;
   display: inline-block;
   margin: 0.75rem 0 1.25rem;
-  color: color-mix(in srgb, var(--color-foreground) 78%, transparent);
+  color: var(--mn-color);
   font-family: var(--font-handwritten), cursive;
   font-size: 1.35rem;
   line-height: 1.3;
@@ -830,14 +879,18 @@
   }
 }
 
-/* Enclosure mode container. */
+/* Enclosure mode container. `color` is set to --mn-color so the rough-notation
+   SVG bracket (injected as a sibling of the content div) inherits the accent
+   colour via currentColor. The content div resets to foreground. */
 .mdx-margin-enclose {
   position: relative;
   margin: 1rem 0 1.5rem;
+  color: var(--mn-color);
 }
 
 .mdx-margin-enclose__content {
   position: relative;
+  color: var(--color-foreground);
 }
 
 .mdx-margin-enclose__content > :first-child {
@@ -854,7 +907,7 @@
   font-family: var(--font-handwritten), cursive;
   font-size: 1.35rem;
   line-height: 1.3;
-  color: color-mix(in srgb, var(--color-foreground) 78%, transparent);
+  color: var(--mn-color);
   text-align: center;
 }
 
@@ -875,6 +928,84 @@
     text-align: right;
   }
 }
+
+/* ---------------------------------------------------------------------------
+   Callout / admonition blocks (GitHub-style note/tip/warning/caution/important)
+   --------------------------------------------------------------------------- */
+
+.mdx-callout {
+  --co-color: oklch(50% 0.18 250);
+  --co-bg:    oklch(50% 0.18 250 / 0.07);
+
+  position: relative;
+  color: var(--co-color);     /* currentColor for rough-notation SVG stroke */
+  background:  var(--co-bg);
+  border-radius: 0.25rem;
+  padding: 0.875rem 1.125rem;
+  margin: 1.5rem 0;
+}
+
+.mdx-callout__rough-anchor {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+.mdx-callout > svg.rough-annotation {
+  pointer-events: none;
+}
+
+/* Variant colours */
+.mdx-callout[data-type="note"] {
+  --co-color: oklch(50% 0.18 250);
+  --co-bg:    oklch(50% 0.18 250 / 0.07);
+  :is(.dark *) & { --co-color: oklch(68% 0.18 250); --co-bg: oklch(68% 0.18 250 / 0.08); }
+}
+.mdx-callout[data-type="tip"] {
+  --co-color: oklch(48% 0.17 155);
+  --co-bg:    oklch(48% 0.17 155 / 0.07);
+  :is(.dark *) & { --co-color: oklch(65% 0.17 155); --co-bg: oklch(65% 0.17 155 / 0.08); }
+}
+.mdx-callout[data-type="important"] {
+  --co-color: oklch(50% 0.22 300);
+  --co-bg:    oklch(50% 0.22 300 / 0.07);
+  :is(.dark *) & { --co-color: oklch(68% 0.22 300); --co-bg: oklch(68% 0.22 300 / 0.08); }
+}
+.mdx-callout[data-type="warning"] {
+  --co-color: oklch(58% 0.16 75);
+  --co-bg:    oklch(58% 0.16 75 / 0.07);
+  :is(.dark *) & { --co-color: oklch(74% 0.16 75); --co-bg: oklch(74% 0.16 75 / 0.08); }
+}
+.mdx-callout[data-type="caution"] {
+  --co-color: oklch(50% 0.22 25);
+  --co-bg:    oklch(50% 0.22 25 / 0.07);
+  :is(.dark *) & { --co-color: oklch(68% 0.22 25); --co-bg: oklch(68% 0.22 25 / 0.08); }
+}
+
+.mdx-callout__header {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  margin-bottom: 0.5rem;
+  color: var(--co-color);
+  font-weight: 600;
+  font-size: 0.85rem;
+  letter-spacing: 0.01em;
+}
+
+.mdx-callout__body {
+  position: relative;
+  z-index: 1;
+  font-size: 0.925rem;
+  line-height: 1.65;
+  color: var(--color-foreground);
+}
+
+/* Strip margin from first/last children so the block stays tight */
+.mdx-callout__body > :first-child { margin-top: 0; }
+.mdx-callout__body > :last-child  { margin-bottom: 0; }
 
 /* Shiki dual theme support */
 /* Light mode: use inline color/background as-is (set by Shiki) */

--- a/src/components/mdx-components.tsx
+++ b/src/components/mdx-components.tsx
@@ -9,7 +9,9 @@ import {
 } from 'react';
 import { CopyButton } from '@/components/blog/copy-button';
 import { Annotate } from '@/components/mdx/annotate';
+import { Callout } from '@/components/mdx/callout';
 import { MarginNote } from '@/components/mdx/margin-note';
+import { References } from '@/components/mdx/references';
 
 type ImageProps = ComponentPropsWithoutRef<typeof Image>;
 type PreProps = ComponentPropsWithoutRef<'pre'>;
@@ -107,6 +109,19 @@ function FigureImage({
   );
 }
 
+interface AccentProps {
+  children: ReactNode;
+  color?: 'info' | 'tip' | 'warning' | 'danger' | 'purple';
+}
+
+function Accent({ children, color }: AccentProps) {
+  return (
+    <span className="mdx-accent" data-color={color}>
+      {children}
+    </span>
+  );
+}
+
 interface CiteProps {
   n: number | string;
 }
@@ -124,48 +139,6 @@ function Cite({ n }: CiteProps) {
   );
 }
 
-interface ReferenceItem {
-  href: string;
-  label: ReactNode;
-}
-
-interface ReferencesProps {
-  items: ReferenceItem[];
-}
-
-function References({ items }: ReferencesProps) {
-  return (
-    <section className="mdx-references-section" data-footnotes>
-      <h2 id="footnote-label" className="mdx-references-label">
-        References
-      </h2>
-      <ol className="mdx-references">
-        {items.map((item, index) => {
-          const n = index + 1;
-          return (
-            <li key={`${n}-${item.href}`} id={`ref-${n}`}>
-              <a
-                className="mdx-references-link"
-                href={item.href}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                {item.label}
-              </a>{' '}
-              <a
-                className="mdx-references-backref"
-                href={`#cite-${n}`}
-                aria-label={`Back to reference ${n}`}
-              >
-                {'↩'}
-              </a>
-            </li>
-          );
-        })}
-      </ol>
-    </section>
-  );
-}
 
 function Acknowledgements({ children }: { children: ReactNode }) {
   return (
@@ -191,8 +164,10 @@ export const mdxComponents: MDXComponents = {
   a: MdxLink,
   img: MdxImage,
   pre: MdxPre,
+  Accent,
   Acknowledgements,
   Annotate,
+  Callout,
   Cite,
   FigureImage,
   MarginNote,

--- a/src/components/mdx/callout.tsx
+++ b/src/components/mdx/callout.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import type { ReactNode } from 'react';
+import { Info, Lightbulb, TriangleAlert, CircleAlert, Sparkles } from 'lucide-react';
+import { motion, useInView, useReducedMotion } from 'motion/react';
+import { annotate } from '@/lib/vendor/rough-notation';
+import type { RoughAnnotation } from '@/lib/vendor/rough-notation';
+
+export type CalloutType = 'note' | 'tip' | 'important' | 'warning' | 'caution';
+
+interface CalloutProps {
+  type?: CalloutType;
+  title?: string;
+  children: ReactNode;
+}
+
+const config: Record<CalloutType, { label: string; Icon: React.ComponentType<{ size?: number }> }> = {
+  note:      { label: 'Note',      Icon: Info },
+  tip:       { label: 'Tip',       Icon: Lightbulb },
+  important: { label: 'Important', Icon: Sparkles },
+  warning:   { label: 'Warning',   Icon: TriangleAlert },
+  caution:   { label: 'Caution',   Icon: CircleAlert },
+};
+
+export function Callout({ type = 'note', title, children }: CalloutProps) {
+  const { label, Icon } = config[type];
+  const ref = useRef<HTMLDivElement>(null);
+  const roughRef = useRef<HTMLSpanElement>(null);
+  const annotationRef = useRef<RoughAnnotation | null>(null);
+  const inView = useInView(ref, { once: true, margin: '-8% 0px' });
+  const reduced = useReducedMotion();
+
+  useEffect(() => {
+    const el = roughRef.current;
+    if (!el) return;
+    const annotation = annotate(el, {
+      type: 'box',
+      strokeWidth: 1.5,
+      color: 'currentColor',
+      animationDuration: reduced ? 0 : 500,
+      animate: !reduced,
+      padding: 0,
+      iterations: 1,
+    });
+    annotationRef.current = annotation;
+    return () => {
+      annotation.remove();
+      annotationRef.current = null;
+    };
+  }, [reduced]);
+
+  useEffect(() => {
+    if (!inView) return;
+    const annotation = annotationRef.current;
+    if (!annotation) return;
+    const id = setTimeout(() => annotation.show(), reduced ? 0 : 380);
+    return () => clearTimeout(id);
+  }, [inView, reduced]);
+
+  return (
+    <motion.div
+      ref={ref}
+      className="mdx-callout"
+      data-type={type}
+      role="note"
+      initial={{ opacity: 0, y: reduced ? 0 : 10 }}
+      animate={inView ? { opacity: 1, y: 0 } : undefined}
+      transition={{ duration: 0.35, ease: 'easeOut' }}
+    >
+      <span ref={roughRef} className="mdx-callout__rough-anchor" aria-hidden />
+      <div className="mdx-callout__header">
+        <motion.span
+          aria-hidden
+          initial={{ scale: reduced ? 1 : 0.5, opacity: reduced ? 1 : 0 }}
+          animate={inView ? { scale: 1, opacity: 1 } : undefined}
+          transition={{ type: 'spring', stiffness: 320, damping: 16, delay: 0.12 }}
+        >
+          <Icon size={15} />
+        </motion.span>
+        <span>{title ?? label}</span>
+      </div>
+      <div className="mdx-callout__body">{children}</div>
+    </motion.div>
+  );
+}

--- a/src/components/mdx/margin-note.tsx
+++ b/src/components/mdx/margin-note.tsx
@@ -9,6 +9,8 @@ import {
   type RoughAnnotation,
 } from '@/lib/vendor/rough-notation';
 
+type MarginNoteColor = 'info' | 'tip' | 'warning' | 'danger' | 'purple';
+
 interface MarginNoteProps {
   children: ReactNode;
   /**
@@ -20,7 +22,9 @@ interface MarginNoteProps {
    * Omit `text` and the component renders in *standalone* mode: `children`
    * is the handwritten note, anchored to the previous paragraph.
    */
-  text?: string;
+  text?: ReactNode;
+  /** Accent colour for the note text and rough-notation bracket. */
+  color?: MarginNoteColor;
 }
 
 // rough-notation accepts a total duration and apportions it across paths
@@ -104,21 +108,23 @@ function RoughBracket({ brackets, targetRef, className }: RoughBracketProps) {
   return <span ref={hostRef} aria-hidden className={className} />;
 }
 
-export function MarginNote({ children, text }: MarginNoteProps) {
+export function MarginNote({ children, text, color }: MarginNoteProps) {
   const isDesktop = useIsDesktop();
 
   if (text) {
-    return <EnclosureMarginNote text={text} isDesktop={isDesktop}>{children}</EnclosureMarginNote>;
+    return <EnclosureMarginNote text={text} color={color} isDesktop={isDesktop}>{children}</EnclosureMarginNote>;
   }
 
-  return <StandaloneMarginNote isDesktop={isDesktop}>{children}</StandaloneMarginNote>;
+  return <StandaloneMarginNote color={color} isDesktop={isDesktop}>{children}</StandaloneMarginNote>;
 }
 
 function StandaloneMarginNote({
   children,
+  color,
   isDesktop,
 }: {
   children: ReactNode;
+  color?: MarginNoteColor;
   isDesktop: boolean;
 }) {
   // The bracket wraps the handwritten note itself. On desktop the bracket is
@@ -128,7 +134,7 @@ function StandaloneMarginNote({
   const brackets: BracketType[] = isDesktop ? ['right'] : ['bottom'];
 
   return (
-    <span className="mdx-margin-note" role="note">
+    <span className="mdx-margin-note" data-color={color} role="note">
       <span ref={textRef} className="mdx-margin-note__text">
         {children}
       </span>
@@ -144,10 +150,12 @@ function StandaloneMarginNote({
 function EnclosureMarginNote({
   children,
   text,
+  color,
   isDesktop,
 }: {
   children: ReactNode;
-  text: string;
+  text: ReactNode;
+  color?: MarginNoteColor;
   isDesktop: boolean;
 }) {
   // The bracket wraps the *content block*. Desktop: vertical `[` in the left
@@ -156,7 +164,7 @@ function EnclosureMarginNote({
   const brackets: BracketType[] = isDesktop ? ['left'] : ['bottom'];
 
   return (
-    <div className="mdx-margin-enclose">
+    <div className="mdx-margin-enclose" data-color={color}>
       <div ref={contentRef} className="mdx-margin-enclose__content">
         {children}
       </div>

--- a/src/components/mdx/references.tsx
+++ b/src/components/mdx/references.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { useRef } from 'react';
+import type { ReactNode } from 'react';
+import { motion, useInView, useReducedMotion } from 'motion/react';
+
+interface ReferenceItem {
+  href: string;
+  label: ReactNode;
+}
+
+interface ReferencesProps {
+  items: ReferenceItem[];
+}
+
+export function References({ items }: ReferencesProps) {
+  const sectionRef = useRef<HTMLElement>(null);
+  const inView = useInView(sectionRef, { once: true, margin: '-10% 0px' });
+  const reduced = useReducedMotion();
+
+  return (
+    <section ref={sectionRef} className="mdx-references-section" data-footnotes>
+      <h2 id="footnote-label" className="mdx-references-label">
+        References
+      </h2>
+      <ol className="mdx-references">
+        {items.map((item, index) => {
+          const n = index + 1;
+          return (
+            <motion.li
+              key={`${n}-${item.href}`}
+              id={`ref-${n}`}
+              initial={{ opacity: 0, x: reduced ? 0 : -10 }}
+              animate={inView ? { opacity: 1, x: 0 } : undefined}
+              transition={{
+                duration: 0.3,
+                delay: reduced ? 0 : index * 0.055,
+                ease: 'easeOut',
+              }}
+            >
+              <a
+                className="mdx-references-link"
+                href={item.href}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {item.label}
+              </a>{' '}
+              <a
+                className="mdx-references-backref"
+                href={`#cite-${n}`}
+                aria-label={`Back to reference ${n}`}
+              >
+                {'↩'}
+              </a>
+            </motion.li>
+          );
+        })}
+      </ol>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary

- Add `<Callout>` component (note/tip/important/warning/caution) with rough-notation hand-drawn box border, scroll-triggered fade-in, and spring icon animation
- Add `<Accent>` inline component for semantic color highlighting with 5 color variants
- Extract `<References>` into its own client component with staggered scroll-triggered animation
- Add color variant support to `<MarginNote>` (info/tip/warning/danger/purple) and allow `ReactNode` for the `text` prop
- Add `--mn-color` and `--co-color` CSS variable theming systems with dark mode OKLCH variants