### PR TITLE
feat(mdx): add Highlighter component and improve MDX component system

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -802,40 +802,54 @@
 
 .mdx-margin-note[data-color="info"],
 .mdx-margin-enclose[data-color="info"],
-.mdx-accent[data-color="info"] {
+.mdx-highlighter[data-color="info"] {
   --mn-color: oklch(50% 0.18 250);
-  :is(.dark *) & { --mn-color: oklch(68% 0.18 250); }
+  --ac-fill:  oklch(78% 0.18 250 / 0.18);
+  :is(.dark *) & { --mn-color: oklch(68% 0.18 250); --ac-fill: oklch(68% 0.18 250 / 0.22); }
 }
 .mdx-margin-note[data-color="tip"],
 .mdx-margin-enclose[data-color="tip"],
-.mdx-accent[data-color="tip"] {
+.mdx-highlighter[data-color="tip"] {
   --mn-color: oklch(48% 0.17 155);
-  :is(.dark *) & { --mn-color: oklch(65% 0.17 155); }
+  --ac-fill:  oklch(76% 0.17 155 / 0.18);
+  :is(.dark *) & { --mn-color: oklch(65% 0.17 155); --ac-fill: oklch(65% 0.17 155 / 0.22); }
 }
 .mdx-margin-note[data-color="warning"],
 .mdx-margin-enclose[data-color="warning"],
-.mdx-accent[data-color="warning"] {
+.mdx-highlighter[data-color="warning"] {
   --mn-color: oklch(58% 0.16 75);
-  :is(.dark *) & { --mn-color: oklch(74% 0.16 75); }
+  --ac-fill:  oklch(82% 0.16 75 / 0.22);
+  :is(.dark *) & { --mn-color: oklch(74% 0.16 75); --ac-fill: oklch(74% 0.16 75 / 0.28); }
 }
 .mdx-margin-note[data-color="danger"],
 .mdx-margin-enclose[data-color="danger"],
-.mdx-accent[data-color="danger"] {
+.mdx-highlighter[data-color="danger"] {
   --mn-color: oklch(50% 0.22 25);
-  :is(.dark *) & { --mn-color: oklch(68% 0.22 25); }
+  --ac-fill:  oklch(76% 0.22 25 / 0.18);
+  :is(.dark *) & { --mn-color: oklch(68% 0.22 25); --ac-fill: oklch(68% 0.22 25 / 0.22); }
 }
 .mdx-margin-note[data-color="purple"],
 .mdx-margin-enclose[data-color="purple"],
-.mdx-accent[data-color="purple"] {
+.mdx-highlighter[data-color="purple"] {
   --mn-color: oklch(50% 0.22 300);
-  :is(.dark *) & { --mn-color: oklch(68% 0.22 300); }
+  --ac-fill:  oklch(78% 0.22 300 / 0.18);
+  :is(.dark *) & { --mn-color: oklch(68% 0.22 300); --ac-fill: oklch(68% 0.22 300 / 0.22); }
 }
 
 /* Inline accent — colour only, no font change. Falls back to inherited colour
    when no data-color is set (var() on an undefined custom property resolves to
    inherit for inherited properties like color). */
-.mdx-accent {
+.mdx-highlighter {
   color: var(--mn-color);
+}
+
+/* When accent wraps inline code, the code's own background sits on top of the
+   rough-notation highlight SVG (inserted before the span in DOM order). The
+   prose rule .blog-prose code:not(pre code) has specificity (0,1,3) so we
+   need .blog-prose .mdx-highlighter code to win at (0,2,1). */
+.blog-prose .mdx-highlighter code {
+  background-color: transparent;
+  padding-inline: 0;
 }
 
 .mdx-margin-note {

--- a/src/components/mdx-components.tsx
+++ b/src/components/mdx-components.tsx
@@ -8,6 +8,7 @@ import {
   type ReactNode
 } from 'react';
 import { CopyButton } from '@/components/blog/copy-button';
+import { Highlighter } from '@/components/mdx/highlighter';
 import { Annotate } from '@/components/mdx/annotate';
 import { Callout } from '@/components/mdx/callout';
 import { MarginNote } from '@/components/mdx/margin-note';
@@ -109,18 +110,6 @@ function FigureImage({
   );
 }
 
-interface AccentProps {
-  children: ReactNode;
-  color?: 'info' | 'tip' | 'warning' | 'danger' | 'purple';
-}
-
-function Accent({ children, color }: AccentProps) {
-  return (
-    <span className="mdx-accent" data-color={color}>
-      {children}
-    </span>
-  );
-}
 
 interface CiteProps {
   n: number | string;
@@ -164,7 +153,7 @@ export const mdxComponents: MDXComponents = {
   a: MdxLink,
   img: MdxImage,
   pre: MdxPre,
-  Accent,
+  Highlighter,
   Acknowledgements,
   Annotate,
   Callout,

--- a/src/components/mdx/highlighter.tsx
+++ b/src/components/mdx/highlighter.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import type { ReactNode } from 'react';
+import { useInView, useReducedMotion } from 'motion/react';
+import { annotate } from '@/lib/vendor/rough-notation';
+import type { RoughAnnotation } from '@/lib/vendor/rough-notation';
+
+type HighlightIntensity = 'light' | 'medium' | 'strong';
+
+const ITERATIONS: Record<HighlightIntensity, number> = {
+  light:  1,
+  medium: 2,
+  strong: 3,
+};
+
+interface HighlighterProps {
+  children: ReactNode;
+  color?: 'info' | 'tip' | 'warning' | 'danger' | 'purple';
+  intensity?: HighlightIntensity;
+}
+
+export function Highlighter({ children, color, intensity = 'medium' }: HighlighterProps) {
+  const ref = useRef<HTMLSpanElement>(null);
+  const annotationRef = useRef<RoughAnnotation | null>(null);
+  const inView = useInView(ref, { once: true, margin: '-5% 0px' });
+  const reduced = useReducedMotion();
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+
+    const fillColor =
+      window.getComputedStyle(el).getPropertyValue('--ac-fill').trim() ||
+      'oklch(80% 0.12 90 / 0.35)';
+
+    const annotation = annotate(el, {
+      type: 'highlight',
+      color: fillColor,
+      iterations: ITERATIONS[intensity],
+      animationDuration: reduced ? 0 : 500,
+      animate: !reduced,
+    });
+    annotationRef.current = annotation;
+
+    return () => {
+      annotation.remove();
+      annotationRef.current = null;
+    };
+  }, [reduced, color, intensity]);
+
+  useEffect(() => {
+    if (!inView) return;
+    const annotation = annotationRef.current;
+    if (!annotation) return;
+    annotation.show();
+  }, [inView, reduced]);
+
+  return (
+    <span ref={ref} className="mdx-highlighter" data-color={color} data-intensity={intensity}>
+      {children}
+    </span>
+  );
+}

--- a/src/components/mdx/highlighter.tsx
+++ b/src/components/mdx/highlighter.tsx
@@ -18,9 +18,13 @@ interface HighlighterProps {
   children: ReactNode;
   color?: 'info' | 'tip' | 'warning' | 'danger' | 'purple';
   intensity?: HighlightIntensity;
+  /** Padding between the text and the highlight stroke. Defaults to rough-notation's 5px. */
+  padding?: number;
+  /** Stroke width of the highlight. Defaults to rough-notation's built-in value for highlight type. */
+  strokeWidth?: number;
 }
 
-export function Highlighter({ children, color, intensity = 'medium' }: HighlighterProps) {
+export function Highlighter({ children, color, intensity = 'medium', padding, strokeWidth }: HighlighterProps) {
   const ref = useRef<HTMLSpanElement>(null);
   const annotationRef = useRef<RoughAnnotation | null>(null);
   const inView = useInView(ref, { once: true, margin: '-5% 0px' });
@@ -36,10 +40,13 @@ export function Highlighter({ children, color, intensity = 'medium' }: Highlight
 
     const annotation = annotate(el, {
       type: 'highlight',
+      multiline: true,
       color: fillColor,
       iterations: ITERATIONS[intensity],
       animationDuration: reduced ? 0 : 500,
       animate: !reduced,
+      ...(padding !== undefined && { padding }),
+      ...(strokeWidth !== undefined && { strokeWidth }),
     });
     annotationRef.current = annotation;
 
@@ -47,7 +54,7 @@ export function Highlighter({ children, color, intensity = 'medium' }: Highlight
       annotation.remove();
       annotationRef.current = null;
     };
-  }, [reduced, color, intensity]);
+  }, [reduced, color, intensity, padding, strokeWidth]);
 
   useEffect(() => {
     if (!inView) return;

--- a/src/components/mdx/margin-note.tsx
+++ b/src/components/mdx/margin-note.tsx
@@ -25,6 +25,17 @@ interface MarginNoteProps {
   text?: ReactNode;
   /** Accent colour for the note text and rough-notation bracket. */
   color?: MarginNoteColor;
+  /**
+   * Which sides of the bracket to draw on desktop. Defaults to `['right']`
+   * for standalone and `['left']` for enclosure. Pass `['left', 'right']`
+   * for a full enclosing bracket.
+   */
+  bracketDesktop?: BracketType | BracketType[];
+  /**
+   * Which sides of the bracket to draw on mobile. Defaults to `['bottom']`.
+   * Pass `['top', 'bottom']` for a full enclosing bracket.
+   */
+  bracketMobile?: BracketType | BracketType[];
 }
 
 // rough-notation accepts a total duration and apportions it across paths
@@ -108,30 +119,54 @@ function RoughBracket({ brackets, targetRef, className }: RoughBracketProps) {
   return <span ref={hostRef} aria-hidden className={className} />;
 }
 
-export function MarginNote({ children, text, color }: MarginNoteProps) {
+export function MarginNote({ children, text, color, bracketDesktop, bracketMobile }: MarginNoteProps) {
   const isDesktop = useIsDesktop();
 
   if (text) {
-    return <EnclosureMarginNote text={text} color={color} isDesktop={isDesktop}>{children}</EnclosureMarginNote>;
+    return (
+      <EnclosureMarginNote
+        text={text}
+        color={color}
+        isDesktop={isDesktop}
+        bracketDesktop={bracketDesktop}
+        bracketMobile={bracketMobile}
+      >
+        {children}
+      </EnclosureMarginNote>
+    );
   }
 
-  return <StandaloneMarginNote color={color} isDesktop={isDesktop}>{children}</StandaloneMarginNote>;
+  return (
+    <StandaloneMarginNote
+      color={color}
+      isDesktop={isDesktop}
+      bracketDesktop={bracketDesktop}
+      bracketMobile={bracketMobile}
+    >
+      {children}
+    </StandaloneMarginNote>
+  );
 }
 
 function StandaloneMarginNote({
   children,
   color,
   isDesktop,
+  bracketDesktop,
+  bracketMobile,
 }: {
   children: ReactNode;
   color?: MarginNoteColor;
   isDesktop: boolean;
+  bracketDesktop?: BracketType | BracketType[];
+  bracketMobile?: BracketType | BracketType[];
 }) {
-  // The bracket wraps the handwritten note itself. On desktop the bracket is
-  // a vertical `[` on the right edge of the note (between note and prose); on
-  // mobile it's a horizontal `U` below the note.
   const textRef = useRef<HTMLSpanElement>(null);
-  const brackets: BracketType[] = isDesktop ? ['right'] : ['bottom'];
+  const defaultDesktop: BracketType[] = ['right'];
+  const defaultMobile: BracketType[] = ['bottom'];
+  const brackets: BracketType[] = isDesktop
+    ? (bracketDesktop ? ([] as BracketType[]).concat(bracketDesktop) : defaultDesktop)
+    : (bracketMobile  ? ([] as BracketType[]).concat(bracketMobile)  : defaultMobile);
 
   return (
     <span className="mdx-margin-note" data-color={color} role="note">
@@ -152,16 +187,22 @@ function EnclosureMarginNote({
   text,
   color,
   isDesktop,
+  bracketDesktop,
+  bracketMobile,
 }: {
   children: ReactNode;
   text: ReactNode;
   color?: MarginNoteColor;
   isDesktop: boolean;
+  bracketDesktop?: BracketType | BracketType[];
+  bracketMobile?: BracketType | BracketType[];
 }) {
-  // The bracket wraps the *content block*. Desktop: vertical `[` in the left
-  // gutter. Mobile: horizontal `U` below content, with cursive note below.
   const contentRef = useRef<HTMLDivElement>(null);
-  const brackets: BracketType[] = isDesktop ? ['left'] : ['bottom'];
+  const defaultDesktop: BracketType[] = ['left'];
+  const defaultMobile: BracketType[] = ['bottom'];
+  const brackets: BracketType[] = isDesktop
+    ? (bracketDesktop ? ([] as BracketType[]).concat(bracketDesktop) : defaultDesktop)
+    : (bracketMobile  ? ([] as BracketType[]).concat(bracketMobile)  : defaultMobile);
 
   return (
     <div className="mdx-margin-enclose" data-color={color}>


### PR DESCRIPTION
## Summary

- Add `<Highlighter>` client component backed by rough-notation highlight annotation, replacing the static `Accent` span
- Supports `color` variants (info/tip/warning/danger/purple), `intensity` levels (light/medium/strong mapped to rough-notation iterations), `padding`, `strokeWidth`, and multiline text spanning multiple lines
- Add `--ac-fill` CSS variables per color variant for semi-transparent highlight fills; fix inline `<code>` background transparency so highlights show through
- Make `<MarginNote>` bracket sides configurable via `bracketDesktop` and `bracketMobile` props — defaults unchanged, pass e.g. `['left', 'right']` for full enclosing brackets